### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -24,8 +24,8 @@ set(THIRD_PARTY_DIR "${ENGINE_ROOT_DIR}/3rdparty")
 set(ENGINE_ASSET_DIR "/asset")
 set(ENGINE_SCHEMA_DIR "/schema")
 
-if(WIN32)
-  add_definitions("/MP")
+if(MSVC)
+    add_compile_options("/MP")
 endif()
 
 set(vulkan_include ${THIRD_PARTY_DIR}/VulkanSDK/include)


### PR DESCRIPTION
修复 CMakeLists.txt 在 Win 下存在的问题. #9
并将添加该编译选项条件改为更精准的 `MSVC`, 还是有不少 Win 下的用户会使用 GCC 等其他编译套件(如: CLion 用户).