### PR TITLE
Fix typo on the course name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </a>
 </p>
 
-**Pilot Engine** is a tiny game engine used for the [gams104](https://games104.boomingtech.com) course.
+**Pilot Engine** is a tiny game engine used for the [GAMES104](https://games104.boomingtech.com) course.
 
 ## Prerequisites
 


### PR DESCRIPTION
The course name is `GAMES104` but not `gams104` in README.md file. This PR fixes the typo on it.