### PR TITLE
Fix typos & scale to display normally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build Pilot, you must first install the following tools.
 - CMake 3.19 (or more recent)
 - Git 2.1 (or more recent)
 
-### MacOS >= 10.15 (x86_64)
+### macOS >= 10.15 (x86_64)
 - Xcode 12.3 (or more recent)
 - CMake 3.19 (or more recent)
 - Git 2.1 (or more recent)
@@ -45,7 +45,7 @@ Or you can use the following command to generate the **Visual Studio** project f
 cmake -S engine/ -B build
 ```
 
-### Build on MacOS
+### Build on macOS
 
 > The following build instructions only tested on specific hardware of x86_64, and do not support M1 chips. For M1 compatible, we will release later.
 

--- a/engine/source/editor/include/editor_ui.h
+++ b/engine/source/editor/include/editor_ui.h
@@ -49,7 +49,7 @@ namespace Pilot
         void showEditorWorldObjectsWindow(bool* p_open);
         void showEditorFileContentWindow(bool* p_open);
         void showEditorGameWindow(bool* p_open);
-        void showEditorDetialWindow(bool* p_open);
+        void showEditorDetailWindow(bool* p_open);
 
         void onReset();
         void onCursorPos(double xpos, double ypos);

--- a/engine/source/editor/source/editor_ui.cpp
+++ b/engine/source/editor/source/editor_ui.cpp
@@ -1,6 +1,6 @@
 #include "editor/include/editor_ui.h"
 
-#include "editor//include/editor.h"
+#include "editor/include/editor.h"
 
 #include "runtime/core/base/macro.h"
 #include "runtime/core/meta/reflection/reflection.h"
@@ -284,7 +284,7 @@ namespace Pilot
         showEditorWorldObjectsWindow(&asset_window_open);
         showEditorGameWindow(&game_engine_window_open);
         showEditorFileContentWindow(&file_content_window_open);
-        showEditorDetialWindow(&detail_window_open);
+        showEditorDetailWindow(&detail_window_open);
     }
 
     void EditorUI::showEditorMenu(bool* p_open)
@@ -490,7 +490,7 @@ namespace Pilot
         delete[] fields;
     }
 
-    void EditorUI::showEditorDetialWindow(bool* p_open)
+    void EditorUI::showEditorDetailWindow(bool* p_open)
     {
         ImGuiWindowFlags window_flags = ImGuiWindowFlags_None;
 
@@ -662,9 +662,13 @@ namespace Pilot
         new_window_size.x       = ImGui::GetWindowSize().x;
         new_window_size.y       = ImGui::GetWindowSize().y - 38.0f;
 
+        float dpiScale = main_viewport->DpiScale;
         // if (new_window_pos != m_engine_window_pos || new_window_size != m_engine_window_size)
         {
-            m_editor->onWindowChanged(new_window_pos.x, new_window_pos.y, new_window_size.x, new_window_size.y);
+            m_editor->onWindowChanged(dpiScale * new_window_pos.x,
+                                      dpiScale * new_window_pos.y,
+                                      dpiScale * new_window_size.x,
+                                      dpiScale * new_window_size.y);
 
             m_engine_window_pos  = new_window_pos;
             m_engine_window_size = new_window_size;


### PR DESCRIPTION
Typo List:
- README.md: change `MacOS` to `macOS`, see [Apple Trademark List*](https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html)
- engine/source/editor/include/editor_ui.h & engine/source/editor/include/editor_ui.h: `showEditorDetialWindow` to `showEditorDetailWindow`

Scale:
- engine/source/editor/source/editor_ui.cpp