### PR TITLE
Fix: score gpu and rank before check physical device suitability to find the best gpu for rending

### DIFF
--- a/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
@@ -323,24 +323,28 @@ void Pilot::PVulkanContext::initializePhysicalDevice()
         std::vector<VkPhysicalDevice> physical_devices(physical_device_count);
         vkEnumeratePhysicalDevices(_instance, &physical_device_count, physical_devices.data());
 
-        std::vector<std::pair<int,VkPhysicalDevice>> ranked_physical_devices;
-        for(const auto& device : physical_devices) {
+        std::vector<std::pair<int, VkPhysicalDevice>> ranked_physical_devices;
+        for (const auto& device : physical_devices)
+        {
             VkPhysicalDeviceProperties physical_device_properties;
             vkGetPhysicalDeviceProperties(device, &physical_device_properties);
             int score = 0;
 
-            if(physical_device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
-                score += 1000;  
-            } else if(physical_device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) {
+            if (physical_device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+            {
+                score += 1000;
+            }
+            else if (physical_device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
+            {
                 score += 100;
             }
 
-            ranked_physical_devices.push_back({score,device});
+            ranked_physical_devices.push_back({score, device});
         }
 
         std::sort(ranked_physical_devices.begin(), ranked_physical_devices.end());
         std::reverse(ranked_physical_devices.begin(), ranked_physical_devices.end());
-        
+
         for (const auto& device : ranked_physical_devices)
         {
             if (isDeviceSuitable(device.second))

--- a/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
@@ -339,6 +339,7 @@ void Pilot::PVulkanContext::initializePhysicalDevice()
         }
 
         std::sort(ranked_physical_devices.begin(), ranked_physical_devices.end());
+        std::reverse(ranked_physical_devices.begin(), ranked_physical_devices.end());
         
         for (const auto& device : ranked_physical_devices)
         {

--- a/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
@@ -323,11 +323,28 @@ void Pilot::PVulkanContext::initializePhysicalDevice()
         std::vector<VkPhysicalDevice> physical_devices(physical_device_count);
         vkEnumeratePhysicalDevices(_instance, &physical_device_count, physical_devices.data());
 
-        for (const auto& device : physical_devices)
+        std::vector<std::pair<int,VkPhysicalDevice>> ranked_physical_devices;
+        for(const auto& device : physical_devices) {
+            VkPhysicalDeviceProperties physical_device_properties;
+            vkGetPhysicalDeviceProperties(device, &physical_device_properties);
+            int score = 0;
+
+            if(physical_device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+                score += 1000;  
+            } else if(physical_device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) {
+                score += 100;
+            }
+
+            ranked_physical_devices.push_back({score,device});
+        }
+
+        std::sort(ranked_physical_devices.begin(), ranked_physical_devices.end());
+        
+        for (const auto& device : ranked_physical_devices)
         {
-            if (isDeviceSuitable(device))
+            if (isDeviceSuitable(device.second))
             {
-                _physical_device = device;
+                _physical_device = device.second;
                 break;
             }
         }

--- a/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
@@ -342,8 +342,11 @@ void Pilot::PVulkanContext::initializePhysicalDevice()
             ranked_physical_devices.push_back({score, device});
         }
 
-        std::sort(ranked_physical_devices.begin(), ranked_physical_devices.end());
-        std::reverse(ranked_physical_devices.begin(), ranked_physical_devices.end());
+        std::sort(ranked_physical_devices.begin(),
+                  ranked_physical_devices.end(),
+                  [](const std::pair<int, VkPhysicalDevice>& p1, const std::pair<int, VkPhysicalDevice>& p2) {
+                      return p1 > p2;
+                  });
 
         for (const auto& device : ranked_physical_devices)
         {


### PR DESCRIPTION
after modify, vulcan context will first rank gpu, and give score by device type (discrete gpu, integrated gpu or virtual gpu) then give a score(1000 for discrete gpu, 100 for integrated gpu and 0 for others) then sort by score.

In this case, it will first check suitability for better(discrete gpu) first. If the system has a higher scored gpu that suitable it will select the higher scored one, if the higher scored one doesn't support some fatal feature engine need, it will check lower scored gpu. Mean while, we'll get "the best"(in most cases) suitable gpu for vulkan.