### PR TITLE
Exclude 3rdparty/ from root clang-format config

### DIFF
--- a/engine/3rdparty/.clang-format
+++ b/engine/3rdparty/.clang-format
@@ -1,0 +1,3 @@
+# Disable formatting for any code under 3rdparty/
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
Disable formatting for any code under engine/3rdparty/, we should avoid controlling third party code.