### PR TITLE
Eliminate move on return value

### DIFF
--- a/engine/source/runtime/platform/path/path.cpp
+++ b/engine/source/runtime/platform/path/path.cpp
@@ -17,7 +17,7 @@ namespace Pilot
         {
             segments.emplace_back(iter->generic_string());
         }
-        return move(segments);
+        return segments;
     }
 
     const tuple<string, string, string> Path::getFileExtensions(const filesystem::path& file_path) const


### PR DESCRIPTION
Just a little fix here: return value shouldn't be moved as it may inhibit RVO. Ref: [stackoverflow](https://stackoverflow.com/questions/4986673/c11-rvalues-and-move-semantics-confusion-return-statement)
Still reading the full source code:)
