### PR TITLE
Fix std::runtime_error message

### DIFF
--- a/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
@@ -357,9 +357,9 @@ void Pilot::PVulkanContext::initializePhysicalDevice()
             }
         }
 
-        if (VK_NULL_HANDLE == _physical_device)
+        if (_physical_device == VK_NULL_HANDLE)
         {
-            throw std::runtime_error("enumerate physical devices");
+            throw std::runtime_error("failed to find suitable physical devices");
         }
     }
 }

--- a/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
@@ -359,7 +359,7 @@ void Pilot::PVulkanContext::initializePhysicalDevice()
 
         if (_physical_device == VK_NULL_HANDLE)
         {
-            throw std::runtime_error("failed to find suitable physical devices");
+            throw std::runtime_error("failed to find suitable physical device");
         }
     }
 }


### PR DESCRIPTION
更正异常消息.
原本的消息为 `enumerate physical devices`, 但这并不是错误发生的原因. 该异常是在没有找到合适的设备时被抛出, 而不是不能获取设备数据.
因为有一些 Issues 给出了一个异常, 但是却没有给出抛出的具体位置, 给错误排查造成了一定的困惑.