### PR TITLE
Fix some physics issues

### DIFF
--- a/engine/source/runtime/engine.cpp
+++ b/engine/source/runtime/engine.cpp
@@ -8,6 +8,7 @@
 
 #include "runtime/function/framework/world/world_manager.h"
 #include "runtime/function/input/input_system.h"
+#include "runtime/function/physics/physics_system.h"
 #include "runtime/function/render/include/render/framebuffer.h"
 #include "runtime/function/render/include/render/render.h"
 #include "runtime/function/render/include/render/surface.h"
@@ -111,7 +112,7 @@ namespace Pilot
         PublicSingleton<WorldManager>::getInstance().tick(delta_time);
         PublicSingleton<SceneManager>::getInstance().tick(m_tri_frame_buffer.getProducingBuffer());
         PublicSingleton<InputSystem>::getInstance().tick();
-        // PublicSingleton<PhysicsSystem>::getInstance().tick(delta_time);
+        PublicSingleton<PhysicsSystem>::getInstance().tick(delta_time);
     }
 
     bool PilotEngine::rendererTick() { return m_renderer->tick(); }

--- a/engine/source/runtime/function/physics/physics_actor.cpp
+++ b/engine/source/runtime/function/physics/physics_actor.cpp
@@ -137,4 +137,18 @@ namespace Pilot
     }
 
     Matrix3x3 PhysicsActor::getInertiaTensor() const { return m_inverse_inertia_tensor; }
+
+    void PhysicsActor::updateShapesTramsform()
+    {
+        for (auto& shape : m_rigidbody_shapes)
+        {
+            const TransformComponent* transform_component = m_parent_object->tryGetComponentConst(TransformComponent);
+
+            Matrix4x4 global_transform_matrix =
+                transform_component->getTransformConst().getMatrix() * shape->m_local_transform.getMatrix();
+            global_transform_matrix.decomposition(shape->m_global_transform.m_position,
+                                                  shape->m_global_transform.m_scale,
+                                                  shape->m_global_transform.m_rotation);
+        }
+    }
 } // namespace Pilot

--- a/engine/source/runtime/function/physics/physics_actor.h
+++ b/engine/source/runtime/function/physics/physics_actor.h
@@ -45,6 +45,8 @@ namespace Pilot
         void      updateInertiaTensor();
         Matrix3x3 getInertiaTensor() const;
 
+        void updateShapesTramsform();
+
         const std::vector<RigidBodyShapeBase*>& getShapes() const { return m_rigidbody_shapes; }
         Transform&                              getTransform() { return m_global_transform; }
 

--- a/engine/source/runtime/function/physics/physics_system.cpp
+++ b/engine/source/runtime/function/physics/physics_system.cpp
@@ -40,6 +40,7 @@ namespace Pilot
             updateCollisionList(); // Remove any old collisions
 
             integrateVelocity(iteration_delta_time); // update positions from new velocity changes
+            updateShapesTransform();
 
             m_delta_time_offset -= iteration_delta_time;
         }
@@ -118,7 +119,7 @@ namespace Pilot
                 bool is_hit = CollisionDetection::IsOverlap(actor_position,
                                                             box_shape->m_global_transform.m_position,
                                                             actor_half_dimensions,
-                                                            box_shape->m_half_extents);
+                                                            box_shape->m_half_extents * box_shape->m_global_transform.m_scale);
 
                 if (is_hit)
                     return true;
@@ -197,6 +198,12 @@ namespace Pilot
             // std::cout << "actor id : " << i++ << "   after tick pos: " << pos.x << " " << pos.y << " " << pos.z <<
             // std::endl;
         }
+    }
+
+    void PhysicsSystem::updateShapesTransform()
+    {
+        for (auto& actor : m_physics_actors)
+            actor->updateShapesTramsform();
     }
 
     void PhysicsSystem::updateCollisionList()

--- a/engine/source/runtime/function/physics/physics_system.h
+++ b/engine/source/runtime/function/physics/physics_system.h
@@ -34,6 +34,7 @@ namespace Pilot
 
         void integrateAccelerate(float delta_time);
         void integrateVelocity(float delta_time);
+        void updateShapesTransform();
 
         void updateCollisionList();
 


### PR DESCRIPTION
做了以下几个事情:
- `PhysicsShapesBase::m_global_transform` 会在 `PhysicsSystem::tick()` 中被更新. 解决了 #17.
- 修复了原本调用 `CollisionDetection::IsOverlap` 时没有考虑到 `PhysicsShapesBase::m_global_transform::m_scale` 这个因素, 导致物体缩放后碰撞体不正确的问题.

值得关注的地方:
- 更新碰撞体的方法会比较粗暴, 没有进行任何优化. 没找到使用脏标记的好地方.
- 下方代码的注释被取消了, 因为没有找到任何说明(TODO)不清楚当时注释的原因. 如果物理部分还不完善必须注释的话, 也可以在 `PhysicsSystem::overlap()`/`PhysicsSystem::raycast()` 当中调用 `PhysicsSystem::updateShapesTransform()`.
https://github.com/BoomingTech/Pilot/blob/ccec8b2f5a1d43a14dafde817026b6565d1c1d5f/engine/source/runtime/engine.cpp#L114
- 最好让参与物理部分开发的朋友来审核一下, ~我感觉我是乱写的~.