### PR TITLE
Update editor_ui

### DIFF
--- a/engine/source/editor/include/editor_ui.h
+++ b/engine/source/editor/include/editor_ui.h
@@ -10,6 +10,7 @@
 
 #include "editor/include/editor_file_service.h"
 
+#include <chrono>
 #include <map>
 #include <vector>
 
@@ -93,5 +94,8 @@ namespace Pilot
         EditorTranslationAxis m_translation_axis;
         EditorRotationAxis    m_rotation_axis;
         EditorScaleAxis       m_scale_aixs;
+
+        EditorFileService                                  m_editor_file_service;
+        std::chrono::time_point<std::chrono::steady_clock> m_last_file_tree_update;
     };
 } // namespace Pilot

--- a/engine/source/editor/source/editor_ui.cpp
+++ b/engine/source/editor/source/editor_ui.cpp
@@ -553,9 +553,16 @@ namespace Pilot
             ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_NoHide);
             ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
             ImGui::TableHeadersRow();
-            Pilot::EditorFileService editor_file_service;
-            editor_file_service.buildEngineFileTree();
-            EditorFileNode* editor_root_node = editor_file_service.getEditorRootNode();
+
+            auto current_time = std::chrono::steady_clock::now();
+            if (current_time - m_last_file_tree_update > std::chrono::seconds(1))
+            {
+                m_editor_file_service.buildEngineFileTree();
+                m_last_file_tree_update = current_time;
+            }
+            m_last_file_tree_update = current_time;
+
+            EditorFileNode* editor_root_node = m_editor_file_service.getEditorRootNode();
             buildEditorFileAssstsUITree(editor_root_node);
             ImGui::EndTable();
         }


### PR DESCRIPTION
每秒更新一次文件树.
经过简单的性能分析, 这个修改极大的降低了 `EditorFileService::buildEngineFileTree()` 对 CPU 时间的占用.
为了不徒增复杂度, 直接将1秒间隔这个设定硬编码了进去.
- #67 