### PR TITLE
一个很粗劣的imgui高dpi支持方案，但是大部分情况下都管用。影响也小

### DIFF
--- a/engine/source/runtime/function/render/source/surface_ui.cpp
+++ b/engine/source/runtime/function/render/source/surface_ui.cpp
@@ -1,10 +1,12 @@
 #ifndef GLFW_INCLUDE_VULKAN
 #define GLFW_INCLUDE_VULKAN 1
 #endif
+#include "GLFW/glfw3.h"
 
 #include "runtime/function/render/include/render/surface.h"
 #include "runtime/resource/config_manager/config_manager.h"
 
+#include <algorithm>
 #include <backends/imgui_impl_glfw.h>
 #include <backends/imgui_impl_vulkan.h>
 #include <stb_image.h>
@@ -23,8 +25,16 @@ int SurfaceUI::initialize(SurfaceRHI* rhi, PilotRenderer* prenderer, std::shared
     io.ConfigDockingAlwaysTabBar         = true;
     io.ConfigWindowsMoveFromTitleBarOnly = true;
 
-    io.Fonts->AddFontFromFileTTF(
-        ConfigManager::getInstance().getEditorFontPath().generic_string().data(), 16, nullptr, nullptr);
+    {
+        float xscale, yscale;
+        glfwGetMonitorContentScale(glfwGetPrimaryMonitor(), &xscale, &yscale);
+        std::cout<<"scale: "<<xscale<<" "<<yscale<<"\n";
+        float scale_ratio = std::min<float>(xscale, yscale);
+        io.Fonts->AddFontFromFileTTF(ConfigManager::getInstance().getEditorFontPath().generic_string().data(),
+                                     16 * scale_ratio,
+                                     nullptr,
+                                     nullptr);
+    }
     io.Fonts->Build();
     style.WindowPadding   = ImVec2(1.0, 0);
     style.FramePadding    = ImVec2(14.0, 2.0f);


### PR DESCRIPTION
之前在imgui仓库里见到作者说过一次（找不到了），说其实imgui基本上所有控件都会跟着字体自己调整大小，所以就基于字体大小做了个高dpi支持。
因为引擎此时还没有创建glfw窗口，无法获知窗口所在的屏幕，缩放比例就默认为主屏幕的缩放比例了。