### PR TITLE
Fix: format-security

### DIFF
--- a/engine/source/editor/source/editor_ui.cpp
+++ b/engine/source/editor/source/editor_ui.cpp
@@ -1215,7 +1215,7 @@ namespace Pilot
 
         ImGui::Columns(2);
         ImGui::SetColumnWidth(0, columnWidth);
-        ImGui::Text(label.c_str());
+        ImGui::Text("%s", label.c_str());
         ImGui::NextColumn();
 
         ImGui::PushMultiItemsWidths(3, ImGui::CalcItemWidth());
@@ -1271,7 +1271,7 @@ namespace Pilot
 
         ImGui::Columns(2);
         ImGui::SetColumnWidth(0, columnWidth);
-        ImGui::Text(label.c_str());
+        ImGui::Text("%s", label.c_str());
         ImGui::NextColumn();
 
         ImGui::PushMultiItemsWidths(4, ImGui::CalcItemWidth());


### PR DESCRIPTION
Available fix suggestion from clangd: format string is not a string literal (potentially insecure) (fix available) [-Wformat-security].
Also in conformity with  another `ImGui::Text()` calls in this file.

Change list:
- line 1218 & 1274: `ImGui::Text(label.c_str());` to `ImGui::Text("%s", label.c_str());`