### PR TITLE
More fixes

### DIFF
--- a/engine/source/runtime/core/math/vector2.h
+++ b/engine/source/runtime/core/math/vector2.h
@@ -31,6 +31,18 @@ namespace Pilot
 
         const float* ptr() const { return &x; }
 
+        float operator[](size_t i) const
+        {
+            assert(i < 2);
+            return (i == 0 ? x : y);
+        }
+
+        float& operator[](size_t i)
+        {
+            assert(i < 2);
+            return (i == 0 ? x : y);
+        }
+
         bool operator==(const Vector2& rhs) const { return (x == rhs.x && y == rhs.y); }
 
         bool operator!=(const Vector2& rhs) const { return (x != rhs.x || y != rhs.y); }
@@ -236,7 +248,7 @@ namespace Pilot
         */
         Vector2 midPoint(const Vector2& vec) const { return Vector2((x + vec.x) * 0.5f, (y + vec.y) * 0.5f); }
 
-        /** Returnsk_true if the vector's scalar components are all greater
+        /** Returns true if the vector's scalar components are all greater
         that the ones of the vector it is compared against.
         */
         bool operator<(const Vector2& rhs) const
@@ -246,7 +258,7 @@ namespace Pilot
             return false;
         }
 
-        /** Returnsk_true if the vector's scalar components are all smaller
+        /** Returns true if the vector's scalar components are all smaller
         that the ones of the vector it is compared against.
         */
         bool operator>(const Vector2& rhs) const
@@ -301,7 +313,7 @@ namespace Pilot
 
         float crossProduct(const Vector2& rhs) const { return x * rhs.y - y * rhs.x; }
 
-        /** Returnsk_true if this vector is zero length. */
+        /** Returns true if this vector is zero length. */
         bool isZeroLength(void) const
         {
             float sqlen = (x * x) + (y * y);

--- a/engine/source/runtime/function/scene/scene_manager.cpp
+++ b/engine/source/runtime/function/scene/scene_manager.cpp
@@ -323,7 +323,7 @@ namespace Pilot
         return SceneBuffers::imageFromHandle(handle);
     }
 
-    void SceneManager::addSceneObject(const GameObjectDesc&& go_desc) { m_go_descs.push_back(go_desc); }
+    void SceneManager::addSceneObject(const GameObjectDesc& go_desc) { m_go_descs.push_back(go_desc); }
 
     void SceneManager::syncSceneObjects()
     {
@@ -675,7 +675,7 @@ namespace Pilot
             if (m_mesh_handles_to_release.empty())
                 break;
 
-            auto mesh_handle = m_mesh_handles_to_release.front();
+            auto& mesh_handle = m_mesh_handles_to_release.front();
 
             RenderMesh mesh;
             mesh.m_vertexBuffer = mesh_handle.m_vertex_handle;
@@ -712,7 +712,7 @@ namespace Pilot
             if (m_material_handles_to_release.empty())
                 break;
 
-            auto material_handle = m_material_handles_to_release.front();
+            auto& material_handle = m_material_handles_to_release.front();
 
             Material material;
             material.m_baseColorTexture         = material_handle.m_image_handle0;
@@ -749,15 +749,15 @@ namespace Pilot
             if (m_skeleton_binding_handles_to_release.empty())
                 break;
 
-            auto handle = m_skeleton_binding_handles_to_release.front();
+            auto& skeleton_binding_handle = m_skeleton_binding_handles_to_release.front();
 
-            auto find_file = m_handle_skeleton_binding_map.find(handle);
+            auto find_file = m_handle_skeleton_binding_map.find(skeleton_binding_handle);
             if (find_file != m_handle_skeleton_binding_map.end())
             {
                 m_skeleton_binding_handle_map.erase(find_file->second);
-                m_handle_skeleton_binding_map.erase(handle);
+                m_handle_skeleton_binding_map.erase(skeleton_binding_handle);
             }
-            SceneBuffers::destroy(handle);
+            SceneBuffers::destroy(skeleton_binding_handle);
 
             m_skeleton_binding_handles_to_release.pop_front();
 

--- a/engine/source/runtime/function/scene/scene_manager.h
+++ b/engine/source/runtime/function/scene/scene_manager.h
@@ -35,7 +35,7 @@ namespace Pilot
 
         std::shared_ptr<Scene> getCurrentScene() const { return m_scene; }
 
-        void        addSceneObject(const GameObjectDesc&& go_desc);
+        void        addSceneObject(const GameObjectDesc& go_desc);
         void        syncSceneObjects();
         void        addReleaseMeshHandle(const MeshHandle& mesh_handle);
         void        addReleaseMaterialHandle(const PMaterialHandle& material_handle);


### PR DESCRIPTION
1. `Vector2` class is missing a `operator[]` as `Vector3` and `Vector4` does. Also there're 3 typos in the comment.
2. In scene_manager:
https://github.com/BoomingTech/Pilot/blob/5de12a37d1709ced2d2be324ad5f7a88727bfb9b/engine/source/runtime/function/scene/scene_manager.h#L38
this function declares its parameter as `const &&`(seems strange), I suppose it should be either `const &` or `&&`?<br>
https://github.com/BoomingTech/Pilot/blob/5de12a37d1709ced2d2be324ad5f7a88727bfb9b/engine/source/runtime/function/scene/scene_manager.cpp#L678
The release function for mesh, material and skeleton binding use `auto` to get the element from a `std::deque`, which is a copy. Maybe it's better to use a reference. Also renaming the variable `handle` to `skeleton_binding_handle` to keep consistent with its counterparts in mesh and material release function. If the team is working on a bigger refactoring of this class, you can ignore this commit:)