### PR TITLE
Fix singleton classes

### DIFF
--- a/engine/source/editor/include/editor.h
+++ b/engine/source/editor/include/editor.h
@@ -13,9 +13,9 @@ namespace Pilot
     class PilotEditor : public PublicSingleton<PilotEditor>
     {
         friend class EditorUI;
+        friend class PublicSingleton<PilotEditor>;
 
     public:
-        PilotEditor();
         virtual ~PilotEditor();
 
         void initialize(PilotEngine* engine_runtime);
@@ -24,12 +24,12 @@ namespace Pilot
         void run();
 
     protected:
-        // engine interface
+        PilotEditor();
+
         void   onWindowChanged(float pos_x, float pos_y, float width, float height) const;
         size_t onUpdateCursorOnAxis(int axis_mode, const Vector2& cursor_uv, const Vector2& window_size) const;
         size_t getGuidOfPickedMesh(const Vector2& picked_uv) const;
 
-    protected:
         std::shared_ptr<EditorUI> m_editor_ui;
         PilotEngine*              m_engine_runtime {nullptr};
     };

--- a/engine/source/runtime/engine.h
+++ b/engine/source/runtime/engine.h
@@ -51,10 +51,9 @@ namespace Pilot
     {
         friend class PublicSingleton<PilotEngine>;
 
-        PilotEngine(const PilotEngine&) = delete;
-        PilotEngine& operator=(const PilotEngine&) = delete;
-
     protected:
+        PilotEngine();
+
         bool                                  m_is_quit {false};
         std::chrono::steady_clock::time_point m_last_tick_time_point {std::chrono::steady_clock::now()};
 
@@ -65,7 +64,8 @@ namespace Pilot
         bool rendererTick();
 
     public:
-        PilotEngine();
+        PilotEngine(const PilotEngine&) = delete;
+        PilotEngine& operator=(const PilotEngine&) = delete;
 
         void startEngine(const EngineInitParams& param);
         void shutdownEngine();

--- a/engine/source/runtime/function/framework/world/world_manager.h
+++ b/engine/source/runtime/function/framework/world/world_manager.h
@@ -16,8 +16,7 @@ namespace Pilot
         friend class PublicSingleton<WorldManager>;
 
     public:
-        WorldManager() {}
-        ~WorldManager();
+        virtual ~WorldManager();
 
         WorldManager(const WorldManager&) = delete;
         WorldManager& operator=(const WorldManager&) = delete;
@@ -30,6 +29,9 @@ namespace Pilot
 
         void   tick(float delta_time);
         Level* getCurrentActiveLevel() const { return m_current_active_level; }
+
+	protected:
+        WorldManager() = default;
 
     private:
         void processPendingLoadWorld();

--- a/engine/source/runtime/function/framework/world/world_manager.h
+++ b/engine/source/runtime/function/framework/world/world_manager.h
@@ -30,7 +30,7 @@ namespace Pilot
         void   tick(float delta_time);
         Level* getCurrentActiveLevel() const { return m_current_active_level; }
 
-	protected:
+    protected:
         WorldManager() = default;
 
     private:

--- a/engine/source/runtime/function/input/input_system.h
+++ b/engine/source/runtime/function/input/input_system.h
@@ -35,6 +35,8 @@ namespace Pilot
 
     class InputSystem : public PublicSingleton<InputSystem>
     {
+        friend class PublicSingleton<InputSystem>;
+		
         static unsigned int k_complement_control_command;
 
     public:
@@ -52,6 +54,9 @@ namespace Pilot
 
         unsigned int getGameCommand() const { return m_game_command; }
         unsigned int getEditorCommand() const { return m_editor_command; }
+
+	protected:
+        InputSystem() = default;
 
     private:
         void onKeyInEditorMode(int key, int scancode, int action, int mods);

--- a/engine/source/runtime/function/input/input_system.h
+++ b/engine/source/runtime/function/input/input_system.h
@@ -36,7 +36,7 @@ namespace Pilot
     class InputSystem : public PublicSingleton<InputSystem>
     {
         friend class PublicSingleton<InputSystem>;
-		
+
         static unsigned int k_complement_control_command;
 
     public:
@@ -55,7 +55,7 @@ namespace Pilot
         unsigned int getGameCommand() const { return m_game_command; }
         unsigned int getEditorCommand() const { return m_editor_command; }
 
-	protected:
+    protected:
         InputSystem() = default;
 
     private:

--- a/engine/source/runtime/function/ui/ui_system.h
+++ b/engine/source/runtime/function/ui/ui_system.h
@@ -11,13 +11,12 @@ namespace Pilot
     public:
         PUIManager(const PUIManager&) = delete;
         PUIManager& operator=(const PUIManager&) = delete;
-        //
-    protected:
-        PUIManager() = default;
 
-    public:
         int initialize();
         int update();
         int clear();
+
+    protected:
+        PUIManager() = default;
     };
 } // namespace Pilot

--- a/engine/source/runtime/platform/file_service/file_service.h
+++ b/engine/source/runtime/platform/file_service/file_service.h
@@ -9,7 +9,12 @@ namespace Pilot
 {
     class FileService : public PublicSingleton<FileService>
     {
+        friend class PublicSingleton<FileService>;
+
     public:
         const std::vector<std::filesystem::path> getFiles(const std::filesystem::path& directory);
+
+    protected:
+        FileService() = default;
     };
 } // namespace Pilot


### PR DESCRIPTION
修正单例类的实现方式, 确保只会存在一个实例.
值得注意的是因为这些类全部没用使用 final 修饰, 所以我假设都可能被继承. 构造函数的访问限定符为 protected, 如果不会被继承的话最好使用 final 修饰并把构造函数的访问限定符改为 private.