### PR TITLE
Fix image layout transition in 'pick' pass

### DIFF
--- a/engine/source/runtime/function/render/source/vulkan_manager/passes/pick.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/passes/pick.cpp
@@ -60,7 +60,7 @@ namespace Pilot
         color_attachment_description.storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
         color_attachment_description.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         color_attachment_description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        color_attachment_description.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+        color_attachment_description.initialLayout  = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
         color_attachment_description.finalLayout    = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 
         VkAttachmentDescription depth_attachment_description {};
@@ -804,7 +804,7 @@ namespace Pilot
         copy_to_buffer_barrier.pNext               = nullptr;
         copy_to_buffer_barrier.srcAccessMask       = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         copy_to_buffer_barrier.dstAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
-        copy_to_buffer_barrier.oldLayout           = VK_IMAGE_LAYOUT_UNDEFINED;
+        copy_to_buffer_barrier.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy_to_buffer_barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy_to_buffer_barrier.srcQueueFamilyIndex = m_p_vulkan_context->_queue_indices.graphicsFamily.value();
         copy_to_buffer_barrier.dstQueueFamilyIndex = m_p_vulkan_context->_queue_indices.graphicsFamily.value();


### PR DESCRIPTION
The current 'pick' implementation uses an image barrier before the copy command, which transfers the rendered image from `VK_IMAGE_LAYOUT_UNDEFINED` to `VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL`.  According to [vk spec](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageLayout.html), doing so will cause the contents of the image’s memory to be undefined. The expected `oldLayout` is `VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL` specified in the `finalLayout` field of subpass description.

Similarly, an earlier barrier transfers the image's layout from `VK_IMAGE_LAYOUT_UNDEFINED` to `VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL`. This transition is presented again in the renderpass description.

This commit fixes #42 by correcting these layout values.