### PR TITLE
[Fixed] Cursor twinkling in editor mode

### DIFF
--- a/engine/source/editor/source/editor_ui.cpp
+++ b/engine/source/editor/source/editor_ui.cpp
@@ -904,7 +904,7 @@ namespace Pilot
         {
             if (m_io->isMouseButtonDown(GLFW_MOUSE_BUTTON_RIGHT))
             {
-                glfwSetInputMode(m_io->m_window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+                glfwSetInputMode(m_io->m_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
                 m_tmp_uistate->m_editor_camera->rotate(Vector2(ypos - m_mouse_y, xpos - m_mouse_x) * angularVelocity);
             }
             else if (m_io->isMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT))

--- a/engine/source/runtime/function/render/source/surface.cpp
+++ b/engine/source/runtime/function/render/source/surface.cpp
@@ -14,13 +14,10 @@ namespace Pilot
                 m_ui->tick_post(uistate);
                 m_rhi->tick_post(framebuffer);
             }
-            if (m_io->m_is_editor_mode == false && m_io->m_is_focus_mode == true)
+            if (m_io->m_is_editor_mode == false)
             {
-                glfwSetInputMode(m_io->m_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-            }
-            else
-            {
-                glfwSetInputMode(m_io->m_window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+                glfwSetInputMode(
+                    m_io->m_window, GLFW_CURSOR, m_io->m_is_focus_mode ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
             }
             return true;
         }


### PR DESCRIPTION
* `GLFW_CURSOR_HIDDEN` didn't really hide the cursor
* `glfwSetInputMode` got conflict between `editor_ui.cpp` and `surface_io.h`