### PR TITLE
Fix overlapped button, ImGui::Indent should also consider DPI scale

### DIFF
--- a/engine/source/editor/source/editor_ui.cpp
+++ b/engine/source/editor/source/editor_ui.cpp
@@ -617,7 +617,8 @@ namespace Pilot
             ImGui::SameLine();
 
             float indent_val = 0.0f;
-            indent_val       = m_engine_window_size.x - 100.0f;
+            indent_val       = m_engine_window_size.x - 100.0f * indentScale();
+
             ImGui::Indent(indent_val);
             if (m_is_editor_mode)
             {

--- a/engine/source/editor/source/editor_ui.cpp
+++ b/engine/source/editor/source/editor_ui.cpp
@@ -617,7 +617,7 @@ namespace Pilot
             ImGui::SameLine();
 
             float indent_val = 0.0f;
-            indent_val       = m_engine_window_size.x - 100.0f * indentScale();
+            indent_val       = m_engine_window_size.x - 100.0f * getIndentScale();
 
             ImGui::Indent(indent_val);
             if (m_is_editor_mode)

--- a/engine/source/runtime/function/render/include/render/surface.h
+++ b/engine/source/runtime/function/render/include/render/surface.h
@@ -46,8 +46,8 @@ namespace Pilot
         int  clear();
         void setDefaultStyle();
     protected:
-        float contentScale();
-        float indentScale();
+        float getContentScale() const;
+        float getIndentScale() const;
     };
 
     class Surface

--- a/engine/source/runtime/function/render/include/render/surface.h
+++ b/engine/source/runtime/function/render/include/render/surface.h
@@ -45,6 +45,9 @@ namespace Pilot
         void draw_frame();
         int  clear();
         void setDefaultStyle();
+    protected:
+        float contentScale();
+        float indentScale();
     };
 
     class Surface

--- a/engine/source/runtime/function/render/source/surface_ui.cpp
+++ b/engine/source/runtime/function/render/source/surface_ui.cpp
@@ -24,14 +24,14 @@ inline void windowContentScaleCallback(GLFWwindow* window, float x_scale, float 
     windowContentScaleUpdate(fmaxf(x_scale, y_scale));
 }
 
-float SurfaceUI::contentScale()
+float SurfaceUI::getContentScale() const
 {
     float x_scale, y_scale;
     glfwGetWindowContentScale(m_io->m_window, &x_scale, &y_scale);
     return fmaxf(1.0f, fmaxf(x_scale, y_scale));
 }
 
-float SurfaceUI::indentScale()
+float SurfaceUI::getIndentScale() const
 {
 #if defined(__MACH__)
     return 1.0f;
@@ -52,7 +52,7 @@ int SurfaceUI::initialize(SurfaceRHI* rhi, PilotRenderer* prenderer, std::shared
     io.ConfigDockingAlwaysTabBar         = true;
     io.ConfigWindowsMoveFromTitleBarOnly = true;
     
-    float content_scale = contentScale();
+    float content_scale = getContentScale();
     windowContentScaleUpdate(content_scale);
     glfwSetWindowContentScaleCallback(pio->m_window, windowContentScaleCallback);
 

--- a/engine/source/runtime/function/render/source/surface_ui.cpp
+++ b/engine/source/runtime/function/render/source/surface_ui.cpp
@@ -36,7 +36,7 @@ float SurfaceUI::getIndentScale() const
 #if defined(__MACH__)
     return 1.0f;
 #else // Not tested on Linux
-    return contentScale();
+    return getContentScale();
 #endif
 }
 


### PR DESCRIPTION
As the title, there is a button overlapped by other GUI elements while resolution scale is larger than 100%.  #92 
Case `ImGui::Indent` also need consider DPI scale on Windows. 

However, the real problem might be GLFW. It's using virtual resolution on macOS but real pixel resolution on Windows.
Eventually, it will have side-effect on ImGui.

Tested on:
Windows 10 Pro 21h2
macOS BIg sur 11.6.5

Not tested on Linux.