### PR TITLE
Add Visual Studio configuration file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,20 @@
 build/
-.vscode/
 cpm_modules/
 CPM_modules/
 CPM_*.cmake
 .DS_Store
+
+# Visual Studio
+CMakeSettings.json
+
+# Visual Studio Code
+.vscode/
+
+# CLion
+.idea/
+compiledDependencies/
+cmake-build-*
+build-*
 
 # CMake.gitignore https://github.com/github/gitignore/blob/master/CMake.gitignore
 CMakeLists.txt.user
@@ -415,9 +426,3 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-
-# clion
-compiledDependencies/
-cmake-build-*
-build-*
-.idea/


### PR DESCRIPTION
添加了 Visual Studio 的个性化配置文件 并 根据IDE进行了简单的分类.
值得注意的是:
- `CMakeSettings.json` 文件是 Visual Studio 下 CMake 项目会生成的配置文件, 因此归类为 Visual Studio 的配置文件.
- CLion 中可能只有 `.idea` 目录是需要忽略的, 不过这个 PR 没有对其进行修改.