### PR TITLE
🐞 fix: set USE_FOLDERS ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Pilot VERSION 0.1.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(BUILD_SHARED_LIBS OFF)
 
 include(CMakeDependentOption)


### PR DESCRIPTION
When I removed the ``glfw`` vendor, I found that the ``visual studio`` Explorer had no folders. It is best to set ``USE_FOLDERS`` on, even if ``glfw`` ``CMakeLists`` has turned on this property .
![图片1](https://user-images.githubusercontent.com/33944573/164189338-7d5c6f7c-3a83-4753-902c-212225da677b.png)
