### PR TITLE
Disable AMD switchable graphics device to avoid enumerating error

### DIFF
--- a/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/context/vulkan_context.cpp
@@ -93,6 +93,7 @@ void Pilot::PVulkanContext::initialize(GLFWwindow* window)
     // https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
     char const* vk_layer_path = PILOT_XSTR(PILOT_VK_LAYER_PATH);
     SetEnvironmentVariableA("VK_LAYER_PATH", vk_layer_path);
+    SetEnvironmentVariableA("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
 #else
 #error Unknown Compiler
 #endif


### PR DESCRIPTION
The problem is described in this link: [vkEnumeratePhysicalDevices error](https://stackoverflow.com/questions/68109171/vkenumeratephysicaldevices-not-finding-all-gpus).

Tested on the following three platforms:
- only AMD graphics card
- only NVIDIA graphics card
- AMD CPU with graphics card and NVIDIA graphics card