### PR TITLE
Remove unnecessary code + Fix config_manager.h

### DIFF
--- a/engine/source/runtime/engine.h
+++ b/engine/source/runtime/engine.h
@@ -72,9 +72,6 @@ namespace Pilot
         void fps(float delta_time);
 
     public:
-        PilotEngine(const PilotEngine&) = delete;
-        PilotEngine& operator=(const PilotEngine&) = delete;
-
         void startEngine(const EngineInitParams& param);
         void shutdownEngine();
 

--- a/engine/source/runtime/function/framework/world/world_manager.h
+++ b/engine/source/runtime/function/framework/world/world_manager.h
@@ -18,9 +18,6 @@ namespace Pilot
     public:
         virtual ~WorldManager();
 
-        WorldManager(const WorldManager&) = delete;
-        WorldManager& operator=(const WorldManager&) = delete;
-
         void initialize();
         void clear();
 

--- a/engine/source/runtime/function/scene/scene_manager.h
+++ b/engine/source/runtime/function/scene/scene_manager.h
@@ -17,10 +17,6 @@ namespace Pilot
     {
         friend class PublicSingleton<SceneManager>;
 
-    public:
-        SceneManager(const SceneManager&) = delete;
-        SceneManager& operator=(const SceneManager&) = delete;
-
     protected:
         SceneManager()                             = default;
         std::shared_ptr<Scene>             m_scene = std::make_shared<Scene>();

--- a/engine/source/runtime/function/scene/scene_object.h
+++ b/engine/source/runtime/function/scene/scene_object.h
@@ -85,13 +85,6 @@ namespace Pilot
         GameObjectDesc(size_t go_id, const std::vector<GameObjectComponentDesc>& components) :
             m_go_id(go_id), m_components(components)
         {}
-        GameObjectDesc(const GameObjectDesc& t) { *this = t; }
-        GameObjectDesc& operator=(const GameObjectDesc& t)
-        {
-            m_go_id      = t.m_go_id;
-            m_components = t.m_components;
-            return *this;
-        }
 
         size_t                                      getId() const { return m_go_id; }
         const std::vector<GameObjectComponentDesc>& getComponents() const { return m_components; }

--- a/engine/source/runtime/function/ui/ui_system.h
+++ b/engine/source/runtime/function/ui/ui_system.h
@@ -9,9 +9,6 @@ namespace Pilot
         friend class PublicSingleton<PUIManager>;
 
     public:
-        PUIManager(const PUIManager&) = delete;
-        PUIManager& operator=(const PUIManager&) = delete;
-
         int initialize();
         int update();
         int clear();

--- a/engine/source/runtime/resource/config_manager/config_manager.h
+++ b/engine/source/runtime/resource/config_manager/config_manager.h
@@ -10,12 +10,6 @@ namespace Pilot
     {
         friend class PublicSingleton<ConfigManager>;
 
-    public:
-        ConfigManager(const ConfigManager&) = delete;
-        ConfigManager& operator=(const ConfigManager&) = delete;
-        //
-        ConfigManager() = default;
-
     private:
         std::filesystem::path m_root_folder;
         std::filesystem::path m_asset_folder;
@@ -25,6 +19,9 @@ namespace Pilot
         std::filesystem::path m_editor_small_icon_path;
         std::filesystem::path m_editor_font_path;
         std::filesystem::path m_global_rendering_res_path;
+
+    protected:
+        ConfigManager() = default;
 
     public:
         void initialize(const EngineInitParams& init_param);


### PR DESCRIPTION
- 因为 PublicSingleton 是一个不可拷贝的类, 因此其子类不需要再显示声明拷贝构造函数和赋值构造函数删除.
- SceneObject 中的部分函数实现和默认的行为无异, 因此删去.
- 防止单例类 ConfigManager 创建多个实例.