### PR TITLE
AssetManager Load Save Url Refactor

### DIFF
--- a/engine/PilotEditor.ini
+++ b/engine/PilotEditor.ini
@@ -3,5 +3,5 @@ SchemaFolder=schema
 BigIconFile=resource/PilotEditorBigIcon.png
 SmallIconFile=resource/PilotEditorSmallIcon.png
 FontFile=resource/PilotEditorFont.TTF
-DefaultWorld=world/hello.world.json
-GlobalRenderingRes=global/rendering.global.json
+DefaultWorld=asset/world/hello.world.json
+GlobalRenderingRes=asset/global/rendering.global.json

--- a/engine/asset/level/1-1.level.json
+++ b/engine/asset/level/1-1.level.json
@@ -6,20 +6,20 @@
       "name": "Player",
       "transform": {
         "position": {
-            "x": 3,
-            "y": 3,
-            "z": 0
+          "x": 3,
+          "y": 3,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
         "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/character/player/player.object.json"
@@ -28,20 +28,20 @@
       "name": "Wall_1",
       "transform": {
         "position": {
-            "x": 1.94597,
-            "y": -0.38554,
-            "z": 0
+          "x": 1.94597,
+          "y": -0.38554,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999993,
-            "y": 0.999993,
-            "z": 1
+          "x": 0.999993,
+          "y": 0.999993,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -50,20 +50,20 @@
       "name": "Wall_2",
       "transform": {
         "position": {
-            "x": -7.9951,
-            "y": -0.38554,
-            "z": 0
+          "x": -7.9951,
+          "y": -0.38554,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999918,
-            "y": 0.999918,
-            "z": 1
+          "x": 0.999918,
+          "y": 0.999918,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -72,43 +72,42 @@
       "name": "Wall_3",
       "transform": {
         "position": {
-            "x": -14.2042,
-            "y": -0.38554,
-            "z": 0
+          "x": -14.2042,
+          "y": -0.38554,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999902,
-            "y": 0.999902,
-            "z": 1
+          "x": 0.999902,
+          "y": 0.999902,
+          "z": 1
         }
-    },
+      },
       "definition": "asset/objects/environment/wall/wall.object.json"
     },
-    
     {
       "name": "Wall_4",
       "transform": {
         "position": {
-            "x": -23.9528,
-            "y": 8.1511,
-            "z": 0
+          "x": -23.9528,
+          "y": 8.1511,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999856,
-            "y": 0.999856,
-            "z": 1
+          "x": 0.999856,
+          "y": 0.999856,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -117,20 +116,20 @@
       "name": "Wall_5",
       "transform": {
         "position": {
-            "x": -31.1963,
-            "y": 8.1511,
-            "z": 0
+          "x": -31.1963,
+          "y": 8.1511,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.999829,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.999829,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -139,20 +138,20 @@
       "name": "Wall_6",
       "transform": {
         "position": {
-            "x": -31.1344,
-            "y": -6.53789,
-            "z": 0
+          "x": -31.1344,
+          "y": -6.53789,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.839828,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.839828,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -161,20 +160,20 @@
       "name": "Wall_7",
       "transform": {
         "position": {
-            "x": -0.294272,
-            "y": -16.3531,
-            "z": 0
+          "x": -0.294272,
+          "y": -16.3531,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.999829,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.999829,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -183,20 +182,20 @@
       "name": "Wall_8",
       "transform": {
         "position": {
-            "x": 6.32963,
-            "y": -16.3531,
-            "z": 0
+          "x": 6.32963,
+          "y": -16.3531,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.999829,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.999829,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -205,20 +204,20 @@
       "name": "Wall_9",
       "transform": {
         "position": {
-            "x": 28.1092,
-            "y": -9.2787,
-            "z": 0
+          "x": 28.1092,
+          "y": -9.2787,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.999829,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.999829,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -227,43 +226,42 @@
       "name": "Wall_10",
       "transform": {
         "position": {
-            "x": 27.5417,
-            "y": -1.22435,
-            "z": 0
+          "x": 27.5417,
+          "y": -1.22435,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.999829,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.999829,
+          "z": 1
         }
-    },
+      },
       "definition": "asset/objects/environment/wall/wall.object.json"
     },
-    
     {
       "name": "Wall_11",
-      "transform":{
+      "transform": {
         "position": {
-            "x": 24.1145,
-            "y": 11.7602,
-            "z": 0
+          "x": 24.1145,
+          "y": 11.7602,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.999829,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.999829,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -272,20 +270,20 @@
       "name": "Wall_12",
       "transform": {
         "position": {
-            "x": 16.9293,
-            "y": 11.7602,
-            "z": 0
+          "x": 16.9293,
+          "y": 11.7602,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.999829,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.999829,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -294,20 +292,20 @@
       "name": "Wall_13",
       "transform": {
         "position": {
-            "x": -4.55501,
-            "y": 15.5394,
-            "z": 0
+          "x": -4.55501,
+          "y": 15.5394,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
         "scale": {
-            "x": 0.999829,
-            "y": 0.879828,
-            "z": 1
+          "x": 0.999829,
+          "y": 0.879828,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -316,20 +314,20 @@
       "name": "Wall_14",
       "transform": {
         "position": {
-            "x": -0.227576,
-            "y": 20.4413,
-            "z": 0
+          "x": -0.227576,
+          "y": 20.4413,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
         "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -338,20 +336,20 @@
       "name": "Wall_15",
       "transform": {
         "position": {
-            "x": -23.9121,
-            "y": 13.0192,
-            "z": 0
+          "x": -23.9121,
+          "y": 13.0192,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
         "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -360,43 +358,42 @@
       "name": "Wall_16",
       "transform": {
         "position": {
-            "x": -26.9155,
-            "y": -11.4134,
-            "z": 0
+          "x": -26.9155,
+          "y": -11.4134,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
         "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
     },
-  
     {
       "name": "Wall_17",
       "transform": {
         "position": {
-            "x": 23.1772,
-            "y": -13.4053,
-            "z": 0
+          "x": 23.1772,
+          "y": -13.4053,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
         "scale": {
-            "x": 1,
-            "y": 0.86,
-            "z": 1
+          "x": 1,
+          "y": 0.86,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall.object.json"
@@ -404,21 +401,21 @@
     {
       "name": "WallWithDoor_1",
       "transform": {
-        "position":{
-            "x": -19.0837,
-            "y": 3.74536,
-            "z": 0
+        "position": {
+          "x": -19.0837,
+          "y": 3.74536,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 0.86,
-            "z":1
+        "scale": {
+          "x": 1,
+          "y": 0.86,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_with_door.object.json"
@@ -426,21 +423,21 @@
     {
       "name": "WallWithDoor_2",
       "transform": {
-        "position":{
-            "x": -23.8943,
-            "y": 19.4922,
-            "z": 0
+        "position": {
+          "x": -23.8943,
+          "y": 19.4922,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 0.86,
-            "z":1
+        "scale": {
+          "x": 1,
+          "y": 0.86,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_with_door.object.json"
@@ -448,21 +445,21 @@
     {
       "name": "WallWithDoor_3",
       "transform": {
-        "position":{
-            "x": -8.84542,
-            "y": 19.4922,
-            "z": 0
+        "position": {
+          "x": -8.84542,
+          "y": 19.4922,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 0.86,
-            "z":1
+        "scale": {
+          "x": 1,
+          "y": 0.86,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_with_door.object.json"
@@ -470,21 +467,21 @@
     {
       "name": "WallWithDoor_4",
       "transform": {
-        "position":{
-            "x": 20.2928,
-            "y": 15.6586,
-            "z": 0
+        "position": {
+          "x": 20.2928,
+          "y": 15.6586,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 0.86,
-            "z": 1
+        "scale": {
+          "x": 1,
+          "y": 0.86,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_with_door.object.json"
@@ -492,21 +489,21 @@
     {
       "name": "WallWithDoor_5",
       "transform": {
-        "position":{
-            "x": 36.2481,
-            "y": 7.65696,
-            "z": 0
+        "position": {
+          "x": 36.2481,
+          "y": 7.65696,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": -0.707683,
-            "w": 0.70653
+          "x": 0,
+          "y": 0,
+          "z": -0.707683,
+          "w": 0.70653
         },
-        "scale":{
-            "x": 1,
-            "y": 0.86,
-            "z": 1
+        "scale": {
+          "x": 1,
+          "y": 0.86,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_with_door.object.json"
@@ -514,21 +511,21 @@
     {
       "name": "WallWithWindow_1",
       "transform": {
-        "position":{
-            "x": -26.9268,
-            "y": -19.3617,
-            "z": 0
+        "position": {
+          "x": -26.9268,
+          "y": -19.3617,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 1,
-            "z": 1
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_with_window.object.json"
@@ -536,21 +533,21 @@
     {
       "name": "WallWithWindow_2",
       "transform": {
-        "position":{
-            "x": 32.3802,
-            "y": 3.21519,
-            "z": 0
+        "position": {
+          "x": 32.3802,
+          "y": 3.21519,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 1,
-            "z": 1
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_with_window.object.json"
@@ -558,46 +555,46 @@
     {
       "name": "WallBlock_1",
       "transform": {
-        "position":{
-            "x": 5.70719,
-            "y": 13.5344,
-            "z": 0
+        "position": {
+          "x": 5.70719,
+          "y": 13.5344,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 1,
-            "z": 1
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_block.object.json",
-	  "instance_components" : [
-		"asset/objects/environment/wall/components/rigid_body/wall_block.rigid_body.component.json"
-	  ]
+      "instance_components": [
+        "asset/objects/environment/wall/components/rigid_body/wall_block.rigid_body.component.json"
+      ]
     },
     {
       "name": "WallBlock_2",
       "transform": {
-        "position":{
-            "x": 3.87136,
-            "y": -1.51802,
-            "z": 0
+        "position": {
+          "x": 3.87136,
+          "y": -1.51802,
+          "z": 0
         },
         "rotation": {
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 1,
-            "z": 1
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/wall/wall_block.object.json"
@@ -606,20 +603,20 @@
       "name": "Stairs",
       "transform": {
         "position": {
-            "x": 5.87136,
-            "y": -1.51802,
-            "z": 0
+          "x": 5.87136,
+          "y": -1.51802,
+          "z": 0
         },
-        "rotation":{
-            "x": 0,
-            "y": 0,
-            "z": 0,
-            "w": 1
+        "rotation": {
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "w": 1
         },
-        "scale":{
-            "x": 1,
-            "y": 1,
-            "z": 1
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
         }
       },
       "definition": "asset/objects/environment/stairs/stairs.object.json"
@@ -660,4 +657,3 @@
     }
   ]
 }
-

--- a/engine/source/runtime/function/animation/animation_loader.cpp
+++ b/engine/source/runtime/function/animation/animation_loader.cpp
@@ -70,39 +70,39 @@ namespace Pilot
         }
     } // namespace
 
-    std::shared_ptr<Pilot::AnimationClip> AnimationLoader::loadAnimationClipData(std::string animation_clip_path)
+    std::shared_ptr<Pilot::AnimationClip> AnimationLoader::loadAnimationClipData(std::string animation_clip_url)
     {
         AssetManager& asset_manager = AssetManager::getInstance();
 
         AnimationAsset animation_clip;
-        asset_manager.loadAsset(asset_manager.getFullPath(animation_clip_path), animation_clip);
+        asset_manager.loadAsset(animation_clip_url, animation_clip);
         return std::make_shared<Pilot::AnimationClip>(animation_clip.clip_data);
     }
 
-    std::shared_ptr<Pilot::SkeletonData> AnimationLoader::loadSkeletonData(std::string skeleton_data_path)
+    std::shared_ptr<Pilot::SkeletonData> AnimationLoader::loadSkeletonData(std::string skeleton_data_url)
     {
         AssetManager& asset_manager = AssetManager::getInstance();
 
         SkeletonData data;
-        asset_manager.loadAsset(asset_manager.getFullPath(skeleton_data_path), data);
+        asset_manager.loadAsset(skeleton_data_url, data);
         return std::make_shared<Pilot::SkeletonData>(data);
     }
 
-    std::shared_ptr<Pilot::AnimSkelMap> AnimationLoader::loadAnimSkelMap(std::string anim_skel_map_path)
+    std::shared_ptr<Pilot::AnimSkelMap> AnimationLoader::loadAnimSkelMap(std::string anim_skel_map_url)
     {
         AssetManager& asset_manager = AssetManager::getInstance();
 
         AnimSkelMap data;
-        asset_manager.loadAsset(asset_manager.getFullPath(anim_skel_map_path), data);
+        asset_manager.loadAsset(anim_skel_map_url, data);
         return std::make_shared<Pilot::AnimSkelMap>(data);
     }
 
-    std::shared_ptr<Pilot::BoneBlendMask> AnimationLoader::loadSkeletonMask(std::string skeleton_mask_file_path)
+    std::shared_ptr<Pilot::BoneBlendMask> AnimationLoader::loadSkeletonMask(std::string skeleton_mask_file_url)
     {
         AssetManager& asset_manager = AssetManager::getInstance();
 
         BoneBlendMask data;
-        asset_manager.loadAsset(asset_manager.getFullPath(skeleton_mask_file_path), data);
+        asset_manager.loadAsset(skeleton_mask_file_url, data);
         return std::make_shared<Pilot::BoneBlendMask>(data);
     }
 

--- a/engine/source/runtime/function/animation/animation_loader.h
+++ b/engine/source/runtime/function/animation/animation_loader.h
@@ -13,9 +13,9 @@ namespace Pilot
     class AnimationLoader
     {
     public:
-        std::shared_ptr<AnimationClip> loadAnimationClipData(std::string animation_clip_path);
-        std::shared_ptr<SkeletonData>  loadSkeletonData(std::string skeleton_data_path);
-        std::shared_ptr<AnimSkelMap>   loadAnimSkelMap(std::string anim_skel_map_path);
-        std::shared_ptr<BoneBlendMask> loadSkeletonMask(std::string skeleton_mask_file_path);
+        std::shared_ptr<AnimationClip> loadAnimationClipData(std::string animation_clip_url);
+        std::shared_ptr<SkeletonData>  loadSkeletonData(std::string skeleton_data_url);
+        std::shared_ptr<AnimSkelMap>   loadAnimSkelMap(std::string anim_skel_map_url);
+        std::shared_ptr<BoneBlendMask> loadSkeletonMask(std::string skeleton_mask_file_url);
     };
 } // namespace Pilot

--- a/engine/source/runtime/function/framework/component/mesh/mesh_component.cpp
+++ b/engine/source/runtime/function/framework/component/mesh/mesh_component.cpp
@@ -28,10 +28,8 @@ namespace Pilot
 
             if (meshComponent.material_desc.with_texture)
             {
-                std::string material_path = asset_manager.getFullPath(sub_mesh.m_material).generic_string();
-
                 MaterialRes material_res;
-                asset_manager.loadAsset(material_path, material_res);
+                asset_manager.loadAsset(sub_mesh.m_material, material_res);
 
                 meshComponent.material_desc.baseColorTextureFile =
                     asset_manager.getFullPath(material_res.m_base_colour_texture_file).generic_string();

--- a/engine/source/runtime/function/framework/level/level.cpp
+++ b/engine/source/runtime/function/framework/level/level.cpp
@@ -67,10 +67,8 @@ namespace Pilot
     {
         m_level_res_url = level_res_url;
 
-        AssetManager& asset_manager = AssetManager::getInstance();
-
         LevelRes level_res;
-        asset_manager.loadAsset(asset_manager.getFullPath(level_res_url), level_res);
+        AssetManager::getInstance().loadAsset(level_res_url, level_res);
 
         for (const ObjectInstanceRes& object_instance_res : level_res.m_objects)
         {
@@ -103,8 +101,7 @@ namespace Pilot
             }
         }
 
-        AssetManager& asset_manager = AssetManager::getInstance();
-        asset_manager.saveAsset(output_level_res, asset_manager.getFullPath(m_level_res_url));
+        AssetManager::getInstance().saveAsset(output_level_res, m_level_res_url);
     }
 
     void Level::tickAll(float delta_time)

--- a/engine/source/runtime/function/framework/object/object.cpp
+++ b/engine/source/runtime/function/framework/object/object.cpp
@@ -34,8 +34,7 @@ namespace Pilot
         setName(object_instance_res.m_name);
 
         // load transform component
-        const Transform& transform               = object_instance_res.m_transform;
-        auto             transform_component_ptr = PILOT_REFLECTION_NEW(TransformComponent, transform, this);
+        auto transform_component_ptr = PILOT_REFLECTION_NEW(TransformComponent, object_instance_res.m_transform, this);
         m_components.push_back(transform_component_ptr);
         m_component_type_names.push_back("TransformComponent");
 
@@ -44,13 +43,11 @@ namespace Pilot
         if (loadComponents(object_instance_res.m_instance_components, instance_component_type_set) == false)
             return false;
 
-        AssetManager& asset_manager = AssetManager::getInstance();
         // load object definition components
-        m_definition_url            = object_instance_res.m_definition;
-        std::string definition_path = asset_manager.getFullPath(m_definition_url).generic_string();
+        m_definition_url = object_instance_res.m_definition;
 
         ObjectDefinitionRes definition_res;
-        AssetManager::getInstance().loadAsset(definition_path, definition_res);
+        AssetManager::getInstance().loadAsset(m_definition_url, definition_res);
 
         if (loadComponents(definition_res.m_components, instance_component_type_set) == false)
             return false;
@@ -73,9 +70,9 @@ namespace Pilot
         AssetManager&          asset_manager = AssetManager::getInstance();
         ComponentDefinitionRes definition_res;
 
-        for (const std::string& definition_res_path : components)
+        for (const std::string& definition_res_url : components)
         {
-            asset_manager.loadAsset(asset_manager.getFullPath(definition_res_path), definition_res);
+            asset_manager.loadAsset(definition_res_url, definition_res);
             if (loadComponentDefinition(definition_res, false, out_instance_component_type_set) == false)
                 return false;
         }

--- a/engine/source/runtime/function/framework/world/world_manager.cpp
+++ b/engine/source/runtime/function/framework/world/world_manager.cpp
@@ -45,18 +45,16 @@ namespace Pilot
         if (m_pending_load_world_url.empty())
             return;
 
-        std::filesystem::path pending_load_world_url = m_pending_load_world_url;
+        std::string pending_load_world_url = m_pending_load_world_url;
         clear();
 
         loadWorld(pending_load_world_url);
     }
 
-    void WorldManager::loadWorld(const std::filesystem::path& world_url)
+    void WorldManager::loadWorld(const std::string& world_url)
     {
-        std::filesystem::path pending_load_world_path = ConfigManager::getInstance().getAssetFolder() / world_url;
-
         WorldRes world_res;
-        AssetManager::getInstance().loadAsset(pending_load_world_path.generic_string(), world_res);
+        AssetManager::getInstance().loadAsset(world_url, world_res);
 
         // m_world = pending_load_world;
         m_current_world_url = world_url;

--- a/engine/source/runtime/function/framework/world/world_manager.h
+++ b/engine/source/runtime/function/framework/world/world_manager.h
@@ -34,13 +34,13 @@ namespace Pilot
 
     private:
         void processPendingLoadWorld();
-        void loadWorld(const std::filesystem::path& world_url);
+        void loadWorld(const std::string& world_url);
         void loadLevel(const std::string& level_url);
 
-        std::filesystem::path m_pending_load_world_url;
-        std::filesystem::path m_pending_load_level_url;
-        std::filesystem::path m_current_world_url;
-        std::string           m_current_level_url;
+        std::string m_pending_load_world_url;
+        std::string m_pending_load_level_url;
+        std::string m_current_world_url;
+        std::string m_current_level_url;
 
         std::vector<Level*> m_levels;
         Level*              m_current_active_level {nullptr};

--- a/engine/source/runtime/function/scene/scene_manager.cpp
+++ b/engine/source/runtime/function/scene/scene_manager.cpp
@@ -313,8 +313,8 @@ namespace Pilot
     {
         GlobalRenderingRes global_rendering_res;
 
-        const auto& global_rendering_res_path = ConfigManager::getInstance().getGlobalRenderingResPath();
-        AssetManager::getInstance().loadAsset(global_rendering_res_path, global_rendering_res);
+        const auto& global_rendering_res_url = ConfigManager::getInstance().getGlobalRenderingResUrl();
+        AssetManager::getInstance().loadAsset(global_rendering_res_url, global_rendering_res);
         setSceneOnce(global_rendering_res);
     }
 
@@ -853,12 +853,8 @@ namespace Pilot
                                                  .generic_string()
                                                  .c_str());
 
-            
-            m_scene->m_color_grading_LUT_texture_handle =
-                SceneBuilder::loadTexture(AssetManager::getInstance()
-                                              .getFullPath(global_res.m_color_grading_map)
-                                              .generic_string()
-                                              .c_str());
+            m_scene->m_color_grading_LUT_texture_handle = SceneBuilder::loadTexture(
+                AssetManager::getInstance().getFullPath(global_res.m_color_grading_map).generic_string().c_str());
 
             m_scene->m_sky_color     = global_res.m_sky_color.toVector3();
             m_scene->m_ambient_light = {global_res.m_ambient_light.toVector3()};

--- a/engine/source/runtime/resource/asset_manager/asset_manager.h
+++ b/engine/source/runtime/resource/asset_manager/asset_manager.h
@@ -19,10 +19,10 @@ namespace Pilot
     {
     public:
         template<typename AssetType>
-        void loadAsset(const std::filesystem::path& asset_path, AssetType& out_asset) const
+        void loadAsset(const std::string& asset_url, AssetType& out_asset) const
         {
             // read json file to string
-            std::ifstream     asset_json_file(asset_path);
+            std::ifstream     asset_json_file(getFullPath(asset_url));
             std::stringstream buffer;
             buffer << asset_json_file.rdbuf();
             std::string asset_json_text(buffer.str());
@@ -36,14 +36,14 @@ namespace Pilot
         }
 
         template<typename AssetType>
-        void saveAsset(const AssetType& out_asset, const std::filesystem::path& asset_path) const
+        void saveAsset(const AssetType& out_asset, const std::string& asset_url) const
         {
             // write to json object and dump to string
             auto&&        asset_json      = PSerializer::write(out_asset);
             std::string&& asset_json_text = asset_json.dump();
 
             // write to file
-            std::ofstream asset_json_file(asset_path);
+            std::ofstream asset_json_file(getFullPath(asset_url));
             asset_json_file << asset_json_text;
             asset_json_file.flush();
         }
@@ -65,9 +65,9 @@ namespace Pilot
         }
 
 #define REGISTER_COMPONENT(COMPONENT_TYPE, COMPONENT_RES_TYPE, TICK_IN_EDITOR_MODE) \
-    registerComponentType(#COMPONENT_TYPE, [this](std::string component_res_file, GObject* parent_object) { \
+    registerComponentType(#COMPONENT_TYPE, [this](std::string component_res_url, GObject* parent_object) { \
         COMPONENT_RES_TYPE component_res; \
-        loadAsset(getFullPath(component_res_file), component_res); \
+        loadAsset(component_res_url, component_res); \
         auto component                   = PILOT_REFLECTION_NEW(COMPONENT_TYPE, component_res, parent_object); \
         component->m_tick_in_editor_mode = TICK_IN_EDITOR_MODE; \
         return component; \

--- a/engine/source/runtime/resource/config_manager/config_manager.cpp
+++ b/engine/source/runtime/resource/config_manager/config_manager.cpp
@@ -28,7 +28,7 @@ namespace Pilot
                 }
                 else if (name == "DefaultWorld")
                 {
-                    m_default_world_path = m_asset_folder / value;
+                    m_default_world_url = value;
                 }
                 else if (name == "BigIconFile")
                 {
@@ -44,7 +44,7 @@ namespace Pilot
                 }
                 else if (name == "GlobalRenderingRes")
                 {
-                    m_global_rendering_res_path = m_asset_folder / value;
+                    m_global_rendering_res_url = value;
                 }
             }
         }
@@ -55,7 +55,7 @@ namespace Pilot
         m_root_folder.clear();
         m_asset_folder.clear();
         m_schema_folder.clear();
-        m_default_world_path.clear();
+        m_default_world_url.clear();
     }
 
     const std::filesystem::path& ConfigManager::getRootFolder() const { return m_root_folder; }
@@ -64,16 +64,13 @@ namespace Pilot
 
     const std::filesystem::path& ConfigManager::getSchemaFolder() const { return m_schema_folder; }
 
-    const std::filesystem::path& ConfigManager::getDefaultWorldUrl() const { return m_default_world_path; }
-
     const std::filesystem::path& ConfigManager::getEditorBigIconPath() const { return m_editor_big_icon_path; }
 
     const std::filesystem::path& ConfigManager::getEditorSmallIconPath() const { return m_editor_small_icon_path; }
 
     const std::filesystem::path& ConfigManager::getEditorFontPath() const { return m_editor_font_path; }
 
-    const std::filesystem::path& ConfigManager::getGlobalRenderingResPath() const
-    {
-        return m_global_rendering_res_path;
-    }
+    const std::string& ConfigManager::getDefaultWorldUrl() const { return m_default_world_url; }
+
+    const std::string& ConfigManager::getGlobalRenderingResUrl() const { return m_global_rendering_res_url; }
 } // namespace Pilot

--- a/engine/source/runtime/resource/config_manager/config_manager.h
+++ b/engine/source/runtime/resource/config_manager/config_manager.h
@@ -14,11 +14,12 @@ namespace Pilot
         std::filesystem::path m_root_folder;
         std::filesystem::path m_asset_folder;
         std::filesystem::path m_schema_folder;
-        std::filesystem::path m_default_world_path;
         std::filesystem::path m_editor_big_icon_path;
         std::filesystem::path m_editor_small_icon_path;
         std::filesystem::path m_editor_font_path;
-        std::filesystem::path m_global_rendering_res_path;
+
+        std::string m_default_world_url;
+        std::string m_global_rendering_res_url;
 
     protected:
         ConfigManager() = default;
@@ -31,10 +32,11 @@ namespace Pilot
         const std::filesystem::path& getRootFolder() const;
         const std::filesystem::path& getAssetFolder() const;
         const std::filesystem::path& getSchemaFolder() const;
-        const std::filesystem::path& getDefaultWorldUrl() const;
         const std::filesystem::path& getEditorBigIconPath() const;
         const std::filesystem::path& getEditorSmallIconPath() const;
         const std::filesystem::path& getEditorFontPath() const;
-        const std::filesystem::path& getGlobalRenderingResPath() const;
+
+        const std::string& getDefaultWorldUrl() const;
+        const std::string& getGlobalRenderingResUrl() const;
     };
 } // namespace Pilot


### PR DESCRIPTION
Now AssetManager uses relative path (asset/...) to load/save assets, i.e. the referenced url in assets can be loaded by AssetManager directly, no need to convert to full path anymore