### PR TITLE
Refactor for Documentation 1

### DIFF
--- a/engine/source/runtime/core/meta/reflection/reflection.h
+++ b/engine/source/runtime/core/meta/reflection/reflection.h
@@ -323,6 +323,10 @@ namespace Pilot
 
             T& operator*() { return *(m_instance); }
 
+            T* getPtr() { return m_instance; }
+
+            T* getPtr() const { return m_instance; }
+
             const T& operator*() const { return *(static_cast<const T*>(m_instance)); }
 
             T*& getPtrReference() { return m_instance; }

--- a/engine/source/runtime/function/character/character.cpp
+++ b/engine/source/runtime/function/character/character.cpp
@@ -29,9 +29,6 @@ namespace Pilot
 
     void Character::tick()
     {
-        if (g_is_editor_mode)
-            return;
-
         if (m_character_object == nullptr)
             return;
 

--- a/engine/source/runtime/function/framework/component/animation/animation_component.cpp
+++ b/engine/source/runtime/function/framework/component/animation/animation_component.cpp
@@ -1,32 +1,28 @@
 #include "runtime/function/framework/component/animation/animation_component.h"
 
-#include "runtime/engine.h"
 #include "runtime/function/animation/animation_system.h"
 #include "runtime/function/framework/object/object.h"
 
 namespace Pilot
 {
-    AnimationComponent::AnimationComponent(const AnimationComponentRes& rigidbody_ast, GObject* parent_object) :
+    AnimationComponent::AnimationComponent(const AnimationComponentRes& animation_res, GObject* parent_object) :
         Component(parent_object)
     {
-        animation_component = rigidbody_ast;
-        auto skeleton_res   = AnimationManager::tryLoadSkeleton(animation_component.skeleton_file_path);
+        m_animation_res   = animation_res;
+        auto skeleton_res = AnimationManager::tryLoadSkeleton(animation_res.skeleton_file_path);
 
-        skeleton.buildSkeleton(*skeleton_res);
+        m_skeleton.buildSkeleton(*skeleton_res);
     }
 
     void AnimationComponent::tick(float delta_time)
     {
-        if ((m_tick_in_editor_mode == false) && g_is_editor_mode)
-            return;
+        m_animation_res.blend_state.blend_ratio[0] +=
+            (delta_time / m_animation_res.blend_state.blend_clip_file_length[0]);
+        m_animation_res.blend_state.blend_ratio[0] -= floor(m_animation_res.blend_state.blend_ratio[0]);
 
-        animation_component.blend_state.blend_ratio[0] +=
-            (delta_time / animation_component.blend_state.blend_clip_file_length[0]);
-        animation_component.blend_state.blend_ratio[0] -= floor(animation_component.blend_state.blend_ratio[0]);
-
-        skeleton.applyAnimation(AnimationManager::getBlendStateWithClipData(animation_component.blend_state));
-        animation_component.animation_result = skeleton.outputAnimationResult();
+        m_skeleton.applyAnimation(AnimationManager::getBlendStateWithClipData(m_animation_res.blend_state));
+        m_animation_res.animation_result = m_skeleton.outputAnimationResult();
     }
 
-    const AnimationResult& AnimationComponent::getResult() const { return animation_component.animation_result; }
+    const AnimationResult& AnimationComponent::getResult() const { return m_animation_res.animation_result; }
 } // namespace Pilot

--- a/engine/source/runtime/function/framework/component/animation/animation_component.h
+++ b/engine/source/runtime/function/framework/component/animation/animation_component.h
@@ -11,16 +11,16 @@ namespace Pilot
     {
         REFLECTION_BODY(AnimationComponent)
 
-        Skeleton skeleton;
+        Skeleton m_skeleton;
         META(Enable)
-        AnimationComponentRes animation_component;
+        AnimationComponentRes m_animation_res;
 
     public:
         AnimationComponent() = default;
-        AnimationComponent(const AnimationComponentRes& rigidbody_ast, GObject* parent_object);
+        AnimationComponent(const AnimationComponentRes& animation_res, GObject* parent_object);
 
-        void                   tick(float delta_time) override;
-        void                   destroy() override {}
+        void tick(float delta_time) override;
+
         const AnimationResult& getResult() const;
     };
 } // namespace Pilot

--- a/engine/source/runtime/function/framework/component/camera/camera_component.cpp
+++ b/engine/source/runtime/function/framework/component/camera/camera_component.cpp
@@ -3,7 +3,6 @@
 #include "runtime/core/base/macro.h"
 #include "runtime/core/math/math_headers.h"
 
-#include "runtime/engine.h"
 #include "runtime/function/character/character.h"
 #include "runtime/function/framework/component/transform/transform_component.h"
 #include "runtime/function/framework/level/level.h"
@@ -15,44 +14,32 @@
 
 namespace Pilot
 {
-    CameraComponent::CameraComponent(const CameraComponentRes& camera_param, GObject* parent_object) :
-        Component {parent_object}, m_camera_param {camera_param}
+    CameraComponent::CameraComponent(const CameraComponentRes& camera_res, GObject* parent_object) :
+        Component {parent_object}, m_camera_res {camera_res}
     {
-        const std::string& camera_type_name = camera_param.m_parameter.getTypeName();
-        if (camera_type_name == "FirstPersonCameraParameter")
-        {
-            m_camera_mode              = CameraMode::first_person;
-            m_camera_param.m_parameter = PILOT_REFLECTION_NEW(FirstPersonCameraParameter);
-            *static_cast<FirstPersonCameraParameter*>(m_camera_param.m_parameter) =
-                *static_cast<FirstPersonCameraParameter*>(camera_param.m_parameter.operator->());
-        }
-        else if (camera_type_name == "ThirdPersonCameraParameter")
-        {
-            m_camera_mode              = CameraMode::third_person;
-            m_camera_param.m_parameter = PILOT_REFLECTION_NEW(ThirdPersonCameraParameter);
-            *static_cast<ThirdPersonCameraParameter*>(m_camera_param.m_parameter) =
-                *static_cast<ThirdPersonCameraParameter*>(camera_param.m_parameter.operator->());
-        }
-        else if (camera_type_name == "FreeCameraParameter")
-        {
-            m_camera_mode              = CameraMode::free;
-            m_camera_param.m_parameter = PILOT_REFLECTION_NEW(FreeCameraParameter);
-            *static_cast<FreeCameraParameter*>(m_camera_param.m_parameter) =
-                *static_cast<FreeCameraParameter*>(camera_param.m_parameter.operator->());
-        }
-        else
-        {
-            LOG_ERROR("invalid camera type");
-        }
+		const std::string& camera_type_name = camera_res.m_parameter.getTypeName();
+		if (camera_type_name == "FirstPersonCameraParameter")
+		{
+			m_camera_mode = CameraMode::first_person;
+		}
+		else if (camera_type_name == "ThirdPersonCameraParameter")
+		{
+			m_camera_mode = CameraMode::third_person;
+		}
+		else if (camera_type_name == "FreeCameraParameter")
+		{
+			m_camera_mode = CameraMode::free;
+		}
+		else
+		{
+			LOG_ERROR("invalid camera type");
+		}
 
-        SceneManager::getInstance().setFOV(camera_param.m_parameter->m_fov);
+        SceneManager::getInstance().setFOV(camera_res.m_parameter->m_fov);
     }
 
     void CameraComponent::tick(float delta_time)
     {
-        if (g_is_editor_mode)
-            return;
-
         Level*     current_level     = WorldManager::getInstance().getCurrentActiveLevel();
         Character* current_character = current_level->getCurrentActiveCharacter();
         if (current_character == nullptr)
@@ -88,7 +75,7 @@ namespace Pilot
         q_yaw.fromAngleAxis(InputSystem::getInstance().m_cursor_delta_yaw, Vector3::UNIT_Z);
         q_pitch.fromAngleAxis(InputSystem::getInstance().m_cursor_delta_pitch, m_left);
 
-        const float offset  = static_cast<FirstPersonCameraParameter*>(m_camera_param.m_parameter)->m_vertical_offset;
+        const float offset  = static_cast<FirstPersonCameraParameter*>(m_camera_res.m_parameter)->m_vertical_offset;
         Vector3     eye_pos = current_character->getPosition() + offset * Vector3::UNIT_Z;
 
         m_foward = q_yaw * q_pitch * m_foward;
@@ -112,7 +99,7 @@ namespace Pilot
         if (current_character == nullptr)
             return;
 
-        ThirdPersonCameraParameter* param = static_cast<ThirdPersonCameraParameter*>(m_camera_param.m_parameter);
+        ThirdPersonCameraParameter* param = static_cast<ThirdPersonCameraParameter*>(m_camera_res.m_parameter);
 
         Quaternion q_yaw, q_pitch;
 

--- a/engine/source/runtime/function/framework/component/camera/camera_component.h
+++ b/engine/source/runtime/function/framework/component/camera/camera_component.h
@@ -22,7 +22,7 @@ namespace Pilot
         REFLECTION_BODY(CameraComponent)
     protected:
         META(Enable)
-        CameraComponentRes m_camera_param;
+        CameraComponentRes m_camera_res;
 
         CameraMode m_camera_mode {CameraMode::invalid};
 
@@ -35,7 +35,6 @@ namespace Pilot
         CameraComponent(const CameraComponentRes& camera_param, GObject* parent_object);
 
         void tick(float delta_time) override;
-        void destroy() override {}
 
     private:
         void tickFirstPersonCamera(float delta_time);

--- a/engine/source/runtime/function/framework/component/component.h
+++ b/engine/source/runtime/function/framework/component/component.h
@@ -21,7 +21,6 @@ namespace Pilot
         void setParentObject(GObject * object) { m_parent_object = object; }
 
         virtual void tick(float delta_time) {};
-        virtual void destroy() {};
 
         bool m_tick_in_editor_mode {false};
     };

--- a/engine/source/runtime/function/framework/component/mesh/mesh_component.cpp
+++ b/engine/source/runtime/function/framework/component/mesh/mesh_component.cpp
@@ -1,7 +1,5 @@
 #include "runtime/function/scene/scene_manager.h"
 
-#include "runtime/engine.h"
-
 #include "runtime/resource/asset_manager/asset_manager.h"
 #include "runtime/resource/res_type/data/material.h"
 
@@ -12,14 +10,14 @@
 
 namespace Pilot
 {
-    MeshComponent::MeshComponent(const MeshComponentRes& mesh_ast, GObject* /*unused*/)
+    MeshComponent::MeshComponent(const MeshComponentRes& mesh_res, GObject* /*unused*/)
     {
         AssetManager& asset_manager = AssetManager::getInstance();
 
-        m_raw_meshes.resize(mesh_ast.m_sub_meshes.size());
+        m_raw_meshes.resize(mesh_res.m_sub_meshes.size());
 
         size_t raw_mesh_count = 0;
-        for (const SubMeshRes& sub_mesh : mesh_ast.m_sub_meshes)
+        for (const SubMeshRes& sub_mesh : mesh_res.m_sub_meshes)
         {
             GameObjectComponentDesc& meshComponent = m_raw_meshes[raw_mesh_count];
             meshComponent.mesh_desc.mesh_file = asset_manager.getFullPath(sub_mesh.m_obj_file_ref).generic_string();
@@ -52,9 +50,6 @@ namespace Pilot
 
     void MeshComponent::tick(float delta_time)
     {
-        if ((m_tick_in_editor_mode == false) && g_is_editor_mode)
-            return;
-
         const TransformComponent* transform_component = m_parent_object->tryGetComponentConst(TransformComponent);
         const AnimationComponent* animation_component = m_parent_object->tryGetComponentConst(AnimationComponent);
 

--- a/engine/source/runtime/function/framework/component/mesh/mesh_component.h
+++ b/engine/source/runtime/function/framework/component/mesh/mesh_component.h
@@ -17,6 +17,8 @@ namespace Pilot
         REFLECTION_BODY(MeshComponent)
     private:
         META(Enable)
+        MeshComponentRes m_mesh_res;
+        
         std::vector<GameObjectComponentDesc> m_raw_meshes;
 
     public:
@@ -26,6 +28,5 @@ namespace Pilot
         const std::vector<GameObjectComponentDesc>& getRawMeshes() const { return m_raw_meshes; }
 
         void tick(float delta_time) override;
-        void destroy() override {}
     };
 } // namespace Pilot

--- a/engine/source/runtime/function/framework/component/motor/motor_component.cpp
+++ b/engine/source/runtime/function/framework/component/motor/motor_component.cpp
@@ -3,7 +3,6 @@
 #include "runtime/core/base/macro.h"
 #include "runtime/core/base/public_singleton.h"
 
-#include "runtime/engine.h"
 #include "runtime/function/character/character.h"
 #include "runtime/function/controller/character_controller.h"
 #include "runtime/function/framework/component/animation/animation_component.h"
@@ -50,9 +49,6 @@ namespace Pilot
 
     void MotorComponent::tick(float delta_time)
     {
-        if ((m_tick_in_editor_mode == false) && g_is_editor_mode)
-            return;
-
         tickPlayerMotor(delta_time);
     }
 

--- a/engine/source/runtime/function/framework/component/motor/motor_component.h
+++ b/engine/source/runtime/function/framework/component/motor/motor_component.h
@@ -32,7 +32,6 @@ namespace Pilot
 
         void tick(float delta_time) override;
         void tickPlayerMotor(float delta_time);
-        void destroy() override {}
 
         const Vector3& getTargetPosition() const { return m_target_position; }
 

--- a/engine/source/runtime/function/framework/component/rigidbody/rigidbody_component.cpp
+++ b/engine/source/runtime/function/framework/component/rigidbody/rigidbody_component.cpp
@@ -8,13 +8,13 @@
 
 namespace Pilot
 {
-    RigidBodyComponent::RigidBodyComponent(const RigidBodyComponentRes& rigidbody_ast, GObject* parent_object) :
+    RigidBodyComponent::RigidBodyComponent(const RigidBodyComponentRes& rigidbody_res, GObject* parent_object) :
         Component(parent_object)
     {
         const TransformComponent* parent_transform = m_parent_object->tryGetComponentConst(TransformComponent);
 
         m_physics_actor = PhysicsSystem::getInstance().createPhysicsActor(
-            parent_object, parent_transform->getTransformConst(), rigidbody_ast);
+            parent_object, parent_transform->getTransformConst(), rigidbody_res);
     }
 
     RigidBodyComponent::~RigidBodyComponent()

--- a/engine/source/runtime/function/framework/component/rigidbody/rigidbody_component.h
+++ b/engine/source/runtime/function/framework/component/rigidbody/rigidbody_component.h
@@ -12,14 +12,16 @@ namespace Pilot
     {
         REFLECTION_BODY(RigidBodyComponent)
     public:
+        META(Enable)
+        RigidBodyComponentRes m_rigidbody_res;
+
         PhysicsActor* m_physics_actor {nullptr};
 
         RigidBodyComponent() {}
-        RigidBodyComponent(const RigidBodyComponentRes& rigidbody_ast, GObject* parent_object);
+        RigidBodyComponent(const RigidBodyComponentRes& rigidbody_res, GObject* parent_object);
         ~RigidBodyComponent() override;
 
         void tick(float delta_time) override {}
-        void destroy() override {}
         void updateGlobalTransform(const Transform& transform);
     };
 } // namespace Pilot

--- a/engine/source/runtime/function/framework/component/transform/transform_component.h
+++ b/engine/source/runtime/function/framework/component/transform/transform_component.h
@@ -42,7 +42,6 @@ namespace Pilot
         Matrix4x4 getMatrix() const { return m_transform_buffer[m_current_index].getMatrix(); }
 
         void tick(float delta_time) override;
-        void destroy() override {}
 
         void tryUpdateRigidBodyComponent();
     };

--- a/engine/source/runtime/function/framework/level/level.cpp
+++ b/engine/source/runtime/function/framework/level/level.cpp
@@ -5,6 +5,7 @@
 #include "runtime/resource/asset_manager/asset_manager.h"
 #include "runtime/resource/res_type/common/level.h"
 
+#include "runtime/engine.h"
 #include "runtime/function/character/character.h"
 #include "runtime/function/framework/object/object.h"
 #include "runtime/function/scene/scene_manager.h"
@@ -114,7 +115,7 @@ namespace Pilot
                 id_object_pair.second->tick(delta_time);
             }
         }
-        if (m_current_active_character)
+        if (m_current_active_character && g_is_editor_mode == false)
         {
             m_current_active_character->tick();
         }
@@ -145,7 +146,6 @@ namespace Pilot
                 {
                     m_current_active_character->setObject(nullptr);
                 }
-                object->destory();
             }
             delete object;
         }

--- a/engine/source/runtime/function/framework/object/object.cpp
+++ b/engine/source/runtime/function/framework/object/object.cpp
@@ -1,5 +1,6 @@
 #include "runtime/function/framework/object/object.h"
 
+#include "runtime/engine.h"
 #include "runtime/function/framework/component/component.h"
 #include "runtime/function/framework/component/transform/transform_component.h"
 
@@ -25,6 +26,10 @@ namespace Pilot
     {
         for (auto& component : m_components)
         {
+            if (component->m_tick_in_editor_mode == false && g_is_editor_mode)
+            {
+                continue;
+            }
             component->tick(delta_time);
         }
     }
@@ -35,6 +40,7 @@ namespace Pilot
 
         // load transform component
         auto transform_component_ptr = PILOT_REFLECTION_NEW(TransformComponent, object_instance_res.m_transform, this);
+        transform_component_ptr->m_tick_in_editor_mode = true;
         m_components.push_back(transform_component_ptr);
         m_component_type_names.push_back("TransformComponent");
 
@@ -106,14 +112,6 @@ namespace Pilot
         }
 
         return true;
-    }
-
-    void GObject::destory()
-    {
-        for (auto& component : m_components)
-        {
-            component->destroy();
-        }
     }
 
 } // namespace Pilot

--- a/engine/source/runtime/function/framework/object/object.h
+++ b/engine/source/runtime/function/framework/object/object.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "runtime/function/framework/component/component.h"
+
 #include "runtime/resource/res_type/common/object.h"
 
 #include <memory>
@@ -9,9 +11,6 @@
 
 namespace Pilot
 {
-    class Component;
-    class PObjectT;
-
     // GObject : Game Object base class
     class GObject
     {
@@ -43,8 +42,6 @@ namespace Pilot
 
         void               setName(std::string name) { m_name = name; }
         const std::string& getName() const { return m_name; }
-
-        void destory();
 
         bool hasComponent(const std::string& compenent_type_name) const
         {

--- a/engine/source/runtime/resource/asset_manager/asset_manager.cpp
+++ b/engine/source/runtime/resource/asset_manager/asset_manager.cpp
@@ -18,7 +18,6 @@ namespace Pilot
     void AssetManager::initialize()
     {
         REGISTER_COMPONENT(AnimationComponent, AnimationComponentRes, false);
-        REGISTER_COMPONENT(TransformComponent, Transform, false);
         REGISTER_COMPONENT(MeshComponent, MeshComponentRes, true);
         REGISTER_COMPONENT(RigidBodyComponent, RigidBodyComponentRes, false);
         REGISTER_COMPONENT(CameraComponent, CameraComponentRes, false);

--- a/engine/source/runtime/resource/res_type/components/animation.h
+++ b/engine/source/runtime/resource/res_type/components/animation.h
@@ -37,7 +37,9 @@ namespace Pilot
         std::string skeleton_file_path;
         BlendState  blend_state;
         // animation to skeleton map
-        float           frame_position; // 0-1
+        float       frame_position; // 0-1
+
+        META(Disable)
         AnimationResult animation_result;
     };
 

--- a/engine/source/runtime/resource/res_type/components/camera.cpp
+++ b/engine/source/runtime/resource/res_type/components/camera.cpp
@@ -1,0 +1,33 @@
+#include "runtime/resource/res_type/components/camera.h"
+
+#include "runtime/core/base/macro.h"
+
+namespace Pilot
+{
+	CameraComponentRes::CameraComponentRes(const CameraComponentRes& res)
+	{
+		const std::string& camera_type_name = res.m_parameter.getTypeName();
+		if (camera_type_name == "FirstPersonCameraParameter")
+		{
+			m_parameter = PILOT_REFLECTION_NEW(FirstPersonCameraParameter);
+			*static_cast<FirstPersonCameraParameter*>(m_parameter) =
+				*static_cast<FirstPersonCameraParameter*>(res.m_parameter.getPtr());
+		}
+		else if (camera_type_name == "ThirdPersonCameraParameter")
+		{
+			m_parameter = PILOT_REFLECTION_NEW(ThirdPersonCameraParameter);
+			*static_cast<ThirdPersonCameraParameter*>(m_parameter) =
+				*static_cast<ThirdPersonCameraParameter*>(res.m_parameter.getPtr());
+		}
+		else if (camera_type_name == "FreeCameraParameter")
+		{
+			m_parameter = PILOT_REFLECTION_NEW(FreeCameraParameter);
+			*static_cast<FreeCameraParameter*>(m_parameter) =
+				*static_cast<FreeCameraParameter*>(res.m_parameter.getPtr());
+		}
+		else
+		{
+			LOG_ERROR("invalid camera type");
+		}
+	}
+}

--- a/engine/source/runtime/resource/res_type/components/camera.h
+++ b/engine/source/runtime/resource/res_type/components/camera.h
@@ -55,6 +55,9 @@ namespace Pilot
     public:
         Reflection::ReflectionPtr<CameraParameter> m_parameter;
 
+        CameraComponentRes() = default;
+        CameraComponentRes(const CameraComponentRes& res);
+
         ~CameraComponentRes() { PILOT_REFLECTION_DELETE(m_parameter); }
     };
 } // namespace Pilot


### PR DESCRIPTION
1. removed tick in editor check from each component, check in object tick
2. each component now holds its runtime component data, unified the name of component data to component_name_res
3. removed useless destroy()
4. move deep copy of component data from component constructor to component data class  copy constructor (WIP)