### PR TITLE
Simplify the code.

### DIFF
--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_common.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_common.h
@@ -260,6 +260,5 @@ namespace Pilot
         uint32_t           emissive_image_width;
         uint32_t           emissive_image_height;
         PILOT_PIXEL_FORMAT emissive_image_format;
-        VulkanPBRMaterial* now_material;
     };
 } // namespace Pilot

--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_context.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_context.h
@@ -12,6 +12,8 @@
 
 #include <vk_mem_alloc.h>
 
+#include <unordered_map>
+
 namespace Pilot
 {
     struct QueueFamilyIndices
@@ -27,6 +29,21 @@ namespace Pilot
         VkSurfaceCapabilitiesKHR        capabilities;
         std::vector<VkSurfaceFormatKHR> formats;
         std::vector<VkPresentModeKHR>   presentModes;
+    };
+
+    struct RenderImageCacheVk
+    {
+        VkImage        image;
+        VkImageView    imageView;
+        VkDeviceMemory deviceMemory;
+        VkFormat       format;
+        uint32_t       width;
+        uint32_t       height;
+        uint32_t       arrayLayouts;
+        uint32_t       mipLevels;
+
+        VkImageUsageFlags  usageFlags;
+        VkImageAspectFlags aspectFlags;
     };
 
     class PVulkanContext
@@ -48,10 +65,6 @@ namespace Pilot
         VkExtent2D               _swapchain_extent;
         std::vector<VkImage>     _swapchain_images;
         std::vector<VkImageView> _swapchain_imageviews;
-
-        VkImage        _depth_image        = VK_NULL_HANDLE;
-        VkDeviceMemory _depth_image_memory = VK_NULL_HANDLE;
-        VkImageView    _depth_image_view   = VK_NULL_HANDLE;
 
         std::vector<VkFramebuffer> _swapchain_framebuffers;
 
@@ -91,6 +104,19 @@ namespace Pilot
 
         void createSwapchainImageViews();
         void createFramebufferImageAndView();
+
+        VkImageView GetImageView(size_t imageUniqueId);
+        VkImage GetImage(size_t imageUniqueId);
+
+        void     CreateRenderImage2D(size_t             imageUniqueId,
+                                     VkFormat           format,
+                                     uint32_t           width,
+                                     uint32_t           height,
+                                     VkImageUsageFlags  usageFlags,
+                                     VkImageAspectFlags aspectFlags,
+                                     uint32_t           arrayLayouts,
+                                     uint32_t           mipLevels);
+        VkFormat GetImageFormat(size_t imageUniqueId);
 
     private:
         const std::vector<char const*> m_validation_layers  = {"VK_LAYER_KHRONOS_validation"};
@@ -136,5 +162,7 @@ namespace Pilot
         VkPresentModeKHR
                    chooseSwapchainPresentModeFromDetails(const std::vector<VkPresentModeKHR>& available_present_modes);
         VkExtent2D chooseSwapchainExtentFromDetails(const VkSurfaceCapabilitiesKHR& capabilities);
+
+        std::unordered_map<size_t, RenderImageCacheVk> _image_cache;
     };
 } // namespace Pilot

--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_directional_light_pass.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_directional_light_pass.h
@@ -16,7 +16,7 @@ namespace Pilot
             _mesh_directional_light_shadow_perframe_storage_buffer_object;
 
     private:
-        void setupAttachments();
+        void createImage();
         void setupRenderPass();
         void setupFramebuffer();
         void setupDescriptorSetLayout();

--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_manager.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_manager.h
@@ -209,7 +209,7 @@ namespace Pilot
                                               VulkanMesh&                                   now_mesh);
         bool               updateIndexBuffer(uint32_t index_buffer_size, void* index_buffer_data, VulkanMesh& now_mesh);
         VulkanPBRMaterial& syncMaterial(struct Material const& material, class PilotRenderer* pilot_renderer);
-        void               updateTextureImageData(const PTextureDataToUpdate& texture_data);
+        void updateTextureImageData(const PTextureDataToUpdate& texture_data, VulkanPBRMaterial* now_material);
         bool               initializeTextureImage(VkImage&           image,
                                                   VkImageView&       image_view,
                                                   VmaAllocation&     image_allocation,

--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_passes.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_passes.h
@@ -7,19 +7,14 @@
 
 namespace Pilot
 {
-    struct PLightPassHelperInfo
-    {
-        VkImageView point_light_shadow_color_image_view;
-        VkImageView directional_light_shadow_color_image_view;
-    };
 
     class PColorGradingPass : public PRenderPassBase
     {
     public:
-        void initialize(VkRenderPass render_pass, VkImageView input_attachment);
+        void initialize(VkRenderPass render_pass);
         void draw();
 
-        void updateAfterFramebufferRecreate(VkImageView input_attachment);
+        void updateAfterFramebufferRecreate();
 
     private:
         void setupDescriptorSetLayout();
@@ -30,10 +25,10 @@ namespace Pilot
     class PToneMappingPass : public PRenderPassBase
     {
     public:
-        void initialize(VkRenderPass render_pass, VkImageView input_attachment);
+        void initialize(VkRenderPass render_pass);
         void draw();
 
-        void updateAfterFramebufferRecreate(VkImageView input_attachment);
+        void updateAfterFramebufferRecreate();
 
     private:
         void setupDescriptorSetLayout();
@@ -72,7 +67,7 @@ namespace Pilot
     extern void  surface_ui_on_tick(void* surface_ui, void* ui_state);
     extern float surface_ui_content_scale(void* surface_ui);
 
-    enum
+    enum _main_camera_pass_buffer
     {
         _main_camera_pass_gbuffer_a               = 0,
         _main_camera_pass_gbuffer_b               = 1,
@@ -151,8 +146,6 @@ namespace Pilot
                          uint32_t           current_swapchain_image_index,
                          void*              ui_state);
 
-        void setHelperInfo(const PLightPassHelperInfo& helper_info);
-
         bool                                         m_is_show_axis;
         size_t                                       m_selected_axis;
         MeshPerframeStorageBufferObject              m_mesh_perframe_storage_buffer_object;
@@ -161,8 +154,10 @@ namespace Pilot
 
         void updateAfterFramebufferRecreate();
 
+        std::vector<VkFramebuffer> m_swapchain_framebuffers;
+
     private:
-        void setupAttachments();
+        void createImage();
         void setupRenderPass();
         void setupDescriptorSetLayout();
         void setupPipelines();
@@ -182,11 +177,15 @@ namespace Pilot
         void drawSkybox();
         void drawBillboardParticle();
         void drawAxis();
-
-    private:
-        VkImageView                m_point_light_shadow_color_image_view;
-        VkImageView                m_directional_light_shadow_color_image_view;
-        std::vector<VkFramebuffer> m_swapchain_framebuffers;
     };
 
 } // namespace Pilot
+
+template<>
+struct std::hash<Pilot::_main_camera_pass_buffer>
+{
+    size_t operator()(const Pilot::_main_camera_pass_buffer& rhs) const noexcept
+    {
+        return (size_t)rhs + 10000;
+    }
+};

--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_pick_pass.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_pick_pass.h
@@ -17,7 +17,7 @@ namespace Pilot
         MeshInefficientPickPerframeStorageBufferObject _mesh_inefficient_pick_perframe_storage_buffer_object;
 
     private:
-        void setupAttachments();
+        void createImage();
         void setupRenderPass();
         void setupFramebuffer();
         void setupDescriptorSetLayout();

--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_point_light_pass.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_point_light_pass.h
@@ -15,7 +15,7 @@ namespace Pilot
         MeshPointLightShadowPerframeStorageBufferObject _mesh_point_light_shadow_perframe_storage_buffer_object;
 
     private:
-        void setupAttachments();
+        void createImage();
         void setupRenderPass();
         void setupFramebuffer();
         void setupDescriptorSetLayout();

--- a/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_render_pass.h
+++ b/engine/source/runtime/function/render/include/render/vulkan_manager/vulkan_render_pass.h
@@ -7,6 +7,9 @@
 #include <vector>
 #include <vulkan/vulkan.h>
 
+#include <tuple>
+using std::tuple;
+
 namespace Pilot
 {
     struct PRenderPassHelperInfo
@@ -50,13 +53,6 @@ namespace Pilot
     class PRenderPassBase
     {
     public:
-        struct FrameBufferAttachment
-        {
-            VkImage        image;
-            VkDeviceMemory mem;
-            VkImageView    view;
-            VkFormat       format;
-        };
 
         struct Framebuffer
         {
@@ -64,8 +60,6 @@ namespace Pilot
             int           height;
             VkFramebuffer framebuffer;
             VkRenderPass  render_pass;
-
-            std::vector<FrameBufferAttachment> attachments;
         };
 
         struct Descriptor
@@ -91,7 +85,6 @@ namespace Pilot
         virtual void postInitialize();
 
         virtual VkRenderPass                       getRenderPass();
-        virtual std::vector<VkImageView>           getFramebufferImageViews();
         virtual std::vector<VkDescriptorSetLayout> getDescriptorSetLayouts();
 
         static PVisiableNodes     m_visiable_nodes;
@@ -99,6 +92,18 @@ namespace Pilot
         static PRenderCommandInfo m_command_info;
 
     protected:
+        void                                         FillShaderStageCreateInfo(VkPipelineShaderStageCreateInfo*  fill,
+                                                          VkDevice                          _device,
+                                                          const std::vector<unsigned char>& vert,
+                                                          const std::vector<unsigned char>& frag);
+        void                                         FillShaderStageCreateInfo(VkPipelineShaderStageCreateInfo*  fill,
+                                                          VkDevice                          _device,
+                                                          const std::vector<unsigned char>& vert,
+                                                          const std::vector<unsigned char>& geom,
+                                                          const std::vector<unsigned char>& frag);
+        void                                         ModuleGC();
+        std::vector<tuple<VkDevice, VkShaderModule>> module_reference;
+
         static PVulkanContext*        m_p_vulkan_context;
         static VkDescriptorPool       m_descriptor_pool;
         static PGlobalRenderResource* m_p_global_render_resource;

--- a/engine/source/runtime/function/render/source/vulkan_manager/misc/command_buffer.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/misc/command_buffer.cpp
@@ -3,6 +3,7 @@
 // command pool for submitting drawing commands
 bool Pilot::PVulkanManager::initializeCommandPool()
 {
+    auto&                   _device = m_vulkan_context._device;
     VkCommandPoolCreateInfo command_pool_create_info;
     command_pool_create_info.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
     command_pool_create_info.pNext            = NULL;
@@ -11,7 +12,7 @@ bool Pilot::PVulkanManager::initializeCommandPool()
 
     for (uint32_t i = 0; i < m_max_frames_in_flight; ++i)
     {
-        if (vkCreateCommandPool(m_vulkan_context._device, &command_pool_create_info, NULL, &m_command_pools[i]) !=
+        if (vkCreateCommandPool(_device, &command_pool_create_info, NULL, &m_command_pools[i]) !=
             VK_SUCCESS)
         {
             throw std::runtime_error("vk create command pool");
@@ -24,6 +25,7 @@ bool Pilot::PVulkanManager::initializeCommandPool()
 // allocate command buffer for drawing commands
 bool Pilot::PVulkanManager::initializeCommandBuffers()
 {
+    auto&                       _device = m_vulkan_context._device;
     VkCommandBufferAllocateInfo command_buffer_allocate_info {};
     command_buffer_allocate_info.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
     command_buffer_allocate_info.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -33,7 +35,7 @@ bool Pilot::PVulkanManager::initializeCommandBuffers()
     {
         command_buffer_allocate_info.commandPool = m_command_pools[i];
 
-        if (vkAllocateCommandBuffers(m_vulkan_context._device, &command_buffer_allocate_info, &m_command_buffers[i]) !=
+        if (vkAllocateCommandBuffers(_device, &command_buffer_allocate_info, &m_command_buffers[i]) !=
             VK_SUCCESS)
         {
             throw std::runtime_error("vk allocate command buffers");

--- a/engine/source/runtime/function/render/source/vulkan_manager/misc/sync_primitives.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/misc/sync_primitives.cpp
@@ -4,6 +4,7 @@
 // (m_vulkan_context._swapchain_images --> semaphores, fences)
 bool Pilot::PVulkanManager::createSyncPrimitives()
 {
+        auto& _device = m_vulkan_context._device;
     VkSemaphoreCreateInfo semaphore_create_info {};
     semaphore_create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
@@ -13,15 +14,15 @@ bool Pilot::PVulkanManager::createSyncPrimitives()
 
     for (uint32_t i = 0; i < m_max_frames_in_flight; i++)
     {
-        if (vkCreateSemaphore(m_vulkan_context._device,
+        if (vkCreateSemaphore(_device,
                               &semaphore_create_info,
                               nullptr,
                               &m_image_available_for_render_semaphores[i]) != VK_SUCCESS ||
-            vkCreateSemaphore(m_vulkan_context._device,
+            vkCreateSemaphore(_device,
                               &semaphore_create_info,
                               nullptr,
                               &m_image_finished_for_presentation_semaphores[i]) != VK_SUCCESS ||
-            vkCreateFence(m_vulkan_context._device, &fence_create_info, nullptr, &m_is_frame_in_flight_fences[i]) !=
+            vkCreateFence(_device, &fence_create_info, nullptr, &m_is_frame_in_flight_fences[i]) !=
                 VK_SUCCESS)
         {
             throw std::runtime_error("vk create semaphore & fence");

--- a/engine/source/runtime/function/render/source/vulkan_manager/misc/upload.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/misc/upload.cpp
@@ -35,6 +35,8 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                                                uint16_t*                                     index_buffer_data,
                                                VulkanMesh&                                   now_mesh)
 {
+    auto& _device          = m_vulkan_context._device;
+    auto& _physical_device = m_vulkan_context._physical_device;
     if (enable_vertex_blending)
     {
         assert(0 == (vertex_buffer_size % sizeof(Mesh_PosNormalTangentTex0Vertex)));
@@ -61,8 +63,8 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                                                        vertex_varying_buffer_size + vertex_joint_binding_buffer_size;
         VkBuffer       inefficient_staging_buffer        = VK_NULL_HANDLE;
         VkDeviceMemory inefficient_staging_buffer_memory = VK_NULL_HANDLE;
-        PVulkanUtil::createBuffer(m_vulkan_context._physical_device,
-                                  m_vulkan_context._device,
+        PVulkanUtil::createBuffer(_physical_device,
+                                  _device,
                                   inefficient_staging_buffer_size,
                                   VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -70,7 +72,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                                   inefficient_staging_buffer_memory);
 
         void* inefficient_staging_buffer_data;
-        vkMapMemory(m_vulkan_context._device,
+        vkMapMemory(_device,
                     inefficient_staging_buffer_memory,
                     0,
                     VK_WHOLE_SIZE,
@@ -137,7 +139,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                           joint_binding_buffer_data[vertex_buffer_index].weight3 * inv_total_weight);
         }
 
-        vkUnmapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory);
+        vkUnmapMemory(_device, inefficient_staging_buffer_memory);
 
         // use the vmaAllocator to allocate asset vertex buffer
         VkBufferCreateInfo bufferInfo = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
@@ -204,8 +206,8 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                                 vertex_joint_binding_buffer_size);
 
         // release staging buffer
-        vkDestroyBuffer(m_vulkan_context._device, inefficient_staging_buffer, nullptr);
-        vkFreeMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, nullptr);
+        vkDestroyBuffer(_device, inefficient_staging_buffer, nullptr);
+        vkFreeMemory(_device, inefficient_staging_buffer_memory, nullptr);
 
         // update descriptor set
         VkDescriptorSetAllocateInfo mesh_vertex_blending_per_mesh_descriptor_set_alloc_info;
@@ -216,7 +218,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
         mesh_vertex_blending_per_mesh_descriptor_set_alloc_info.pSetLayouts =
             &m_main_camera_pass._descriptor_infos[PMainCameraPass::LayoutType::_per_mesh].layout;
 
-        if (VK_SUCCESS != vkAllocateDescriptorSets(m_vulkan_context._device,
+        if (VK_SUCCESS != vkAllocateDescriptorSets(_device,
                                                    &mesh_vertex_blending_per_mesh_descriptor_set_alloc_info,
                                                    &now_mesh.mesh_vertex_blending_descriptor_set))
         {
@@ -248,7 +250,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
         mesh_vertex_blending_vertex_Joint_binding_storage_buffer_write_info.pBufferInfo =
             &mesh_vertex_Joint_binding_storage_buffer_info;
 
-        vkUpdateDescriptorSets(m_vulkan_context._device,
+        vkUpdateDescriptorSets(_device,
                                (sizeof(descriptor_writes) / sizeof(descriptor_writes[0])),
                                descriptor_writes,
                                0,
@@ -275,8 +277,8 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
             vertex_position_buffer_size + vertex_varying_enable_blending_buffer_size + vertex_varying_buffer_size;
         VkBuffer       inefficient_staging_buffer        = VK_NULL_HANDLE;
         VkDeviceMemory inefficient_staging_buffer_memory = VK_NULL_HANDLE;
-        PVulkanUtil::createBuffer(m_vulkan_context._physical_device,
-                                  m_vulkan_context._device,
+        PVulkanUtil::createBuffer(_physical_device,
+                                  _device,
                                   inefficient_staging_buffer_size,
                                   VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -284,7 +286,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                                   inefficient_staging_buffer_memory);
 
         void* inefficient_staging_buffer_data;
-        vkMapMemory(m_vulkan_context._device,
+        vkMapMemory(_device,
                     inefficient_staging_buffer_memory,
                     0,
                     VK_WHOLE_SIZE,
@@ -322,7 +324,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                 glm::vec2(vertex_buffer_data[vertex_index].u, vertex_buffer_data[vertex_index].v);
         }
 
-        vkUnmapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory);
+        vkUnmapMemory(_device, inefficient_staging_buffer_memory);
 
         // use the vmaAllocator to allocate asset vertex buffer
         VkBufferCreateInfo bufferInfo = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
@@ -374,8 +376,8 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
                                 vertex_varying_buffer_size);
 
         // release staging buffer
-        vkDestroyBuffer(m_vulkan_context._device, inefficient_staging_buffer, nullptr);
-        vkFreeMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, nullptr);
+        vkDestroyBuffer(_device, inefficient_staging_buffer, nullptr);
+        vkFreeMemory(_device, inefficient_staging_buffer_memory, nullptr);
 
         // update descriptor set
         VkDescriptorSetAllocateInfo mesh_vertex_blending_per_mesh_descriptor_set_alloc_info;
@@ -385,7 +387,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
         mesh_vertex_blending_per_mesh_descriptor_set_alloc_info.descriptorSetCount = 1;
         mesh_vertex_blending_per_mesh_descriptor_set_alloc_info.pSetLayouts =
             &m_main_camera_pass._descriptor_infos[PMainCameraPass::LayoutType::_per_mesh].layout;
-        if (VK_SUCCESS != vkAllocateDescriptorSets(m_vulkan_context._device,
+        if (VK_SUCCESS != vkAllocateDescriptorSets(_device,
                                                    &mesh_vertex_blending_per_mesh_descriptor_set_alloc_info,
                                                    &now_mesh.mesh_vertex_blending_descriptor_set))
         {
@@ -418,7 +420,7 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
         mesh_vertex_blending_vertex_Joint_binding_storage_buffer_write_info.pBufferInfo =
             &mesh_vertex_Joint_binding_storage_buffer_info;
 
-        vkUpdateDescriptorSets(m_vulkan_context._device,
+        vkUpdateDescriptorSets(_device,
                                (sizeof(descriptor_writes) / sizeof(descriptor_writes[0])),
                                descriptor_writes,
                                0,
@@ -430,13 +432,15 @@ bool Pilot::PVulkanManager::updateVertexBuffer(bool                             
 
 bool Pilot::PVulkanManager::updateIndexBuffer(uint32_t index_buffer_size, void* index_buffer_data, VulkanMesh& now_mesh)
 {
+    auto& _device          = m_vulkan_context._device;
+    auto& _physical_device = m_vulkan_context._physical_device;
     // temp staging buffer
     VkDeviceSize buffer_size = index_buffer_size;
 
     VkBuffer       inefficient_staging_buffer;
     VkDeviceMemory inefficient_staging_buffer_memory;
-    PVulkanUtil::createBuffer(m_vulkan_context._physical_device,
-                              m_vulkan_context._device,
+    PVulkanUtil::createBuffer(_physical_device,
+                              _device,
                               buffer_size,
                               VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                               VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -444,9 +448,9 @@ bool Pilot::PVulkanManager::updateIndexBuffer(uint32_t index_buffer_size, void* 
                               inefficient_staging_buffer_memory);
 
     void* staging_buffer_data;
-    vkMapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, 0, buffer_size, 0, &staging_buffer_data);
+    vkMapMemory(_device, inefficient_staging_buffer_memory, 0, buffer_size, 0, &staging_buffer_data);
     memcpy(staging_buffer_data, index_buffer_data, (size_t)buffer_size);
-    vkUnmapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory);
+    vkUnmapMemory(_device, inefficient_staging_buffer_memory);
 
     // use the vmaAllocator to allocate asset index buffer
     VkBufferCreateInfo bufferInfo = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
@@ -468,49 +472,50 @@ bool Pilot::PVulkanManager::updateIndexBuffer(uint32_t index_buffer_size, void* 
         &m_vulkan_context, inefficient_staging_buffer, now_mesh.mesh_index_buffer, 0, 0, buffer_size);
 
     // release temp staging buffer
-    vkDestroyBuffer(m_vulkan_context._device, inefficient_staging_buffer, nullptr);
-    vkFreeMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, nullptr);
+    vkDestroyBuffer(_device, inefficient_staging_buffer, nullptr);
+    vkFreeMemory(_device, inefficient_staging_buffer_memory, nullptr);
 
     // now index buffer is ready for render commands in cmdbind
     return true;
 }
 
-void Pilot::PVulkanManager::updateTextureImageData(const PTextureDataToUpdate& texture_data)
+void Pilot::PVulkanManager::updateTextureImageData(const PTextureDataToUpdate& texture_data,
+                                                   VulkanPBRMaterial*          now_material)
 {
-    initializeTextureImage(texture_data.now_material->base_color_texture_image,
-                           texture_data.now_material->base_color_image_view,
-                           texture_data.now_material->base_color_image_allocation,
+    initializeTextureImage(now_material->base_color_texture_image,
+                           now_material->base_color_image_view,
+                           now_material->base_color_image_allocation,
                            texture_data.base_color_image_width,
                            texture_data.base_color_image_height,
                            texture_data.base_color_image_pixels,
                            texture_data.base_color_image_format);
 
-    initializeTextureImage(texture_data.now_material->metallic_roughness_texture_image,
-                           texture_data.now_material->metallic_roughness_image_view,
-                           texture_data.now_material->metallic_roughness_image_allocation,
+    initializeTextureImage(now_material->metallic_roughness_texture_image,
+                           now_material->metallic_roughness_image_view,
+                           now_material->metallic_roughness_image_allocation,
                            texture_data.metallic_roughness_image_width,
                            texture_data.metallic_roughness_image_height,
                            texture_data.metallic_roughness_image_pixels,
                            texture_data.metallic_roughness_image_format);
 
-    initializeTextureImage(texture_data.now_material->normal_texture_image,
-                           texture_data.now_material->normal_image_view,
-                           texture_data.now_material->normal_image_allocation,
+    initializeTextureImage(now_material->normal_texture_image,
+                           now_material->normal_image_view,
+                           now_material->normal_image_allocation,
                            texture_data.normal_roughness_image_width,
                            texture_data.normal_roughness_image_height,
                            texture_data.normal_roughness_image_pixels,
                            texture_data.normal_roughness_image_format);
 
-    initializeTextureImage(texture_data.now_material->occlusion_texture_image,
-                           texture_data.now_material->occlusion_image_view,
-                           texture_data.now_material->occlusion_image_allocation,
+    initializeTextureImage(now_material->occlusion_texture_image,
+                           now_material->occlusion_image_view,
+                           now_material->occlusion_image_allocation,
                            texture_data.occlusion_image_width,
                            texture_data.occlusion_image_height,
                            texture_data.occlusion_image_pixels,
                            texture_data.occlusion_image_format);
-    initializeTextureImage(texture_data.now_material->emissive_texture_image,
-                           texture_data.now_material->emissive_image_view,
-                           texture_data.now_material->emissive_image_allocation,
+    initializeTextureImage(now_material->emissive_texture_image,
+                           now_material->emissive_image_view,
+                           now_material->emissive_image_allocation,
                            texture_data.emissive_image_width,
                            texture_data.emissive_image_height,
                            texture_data.emissive_image_pixels,
@@ -581,6 +586,8 @@ void Pilot::PVulkanManager::initializeCubeMap(VkImage&             image,
                                               PILOT_PIXEL_FORMAT   texture_image_format,
                                               uint32_t             miplevels)
 {
+    auto&        _device          = m_vulkan_context._device;
+    auto&        _physical_device = m_vulkan_context._physical_device;
     VkDeviceSize texture_layer_byte_size;
     VkDeviceSize cube_byte_size;
     VkFormat     vulkan_image_format;
@@ -649,8 +656,8 @@ void Pilot::PVulkanManager::initializeCubeMap(VkImage&             image,
 
     VkBuffer       inefficient_staging_buffer;
     VkDeviceMemory inefficient_staging_buffer_memory;
-    PVulkanUtil::createBuffer(m_vulkan_context._physical_device,
-                              m_vulkan_context._device,
+    PVulkanUtil::createBuffer(_physical_device,
+                              _device,
                               cube_byte_size,
                               VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                               VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -658,14 +665,14 @@ void Pilot::PVulkanManager::initializeCubeMap(VkImage&             image,
                               inefficient_staging_buffer_memory);
 
     void* data = NULL;
-    vkMapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, 0, cube_byte_size, 0, &data);
+    vkMapMemory(_device, inefficient_staging_buffer_memory, 0, cube_byte_size, 0, &data);
     for (int i = 0; i < 6; i++)
     {
         memcpy((void*)(static_cast<char*>(data) + texture_layer_byte_size * i),
                texture_image_pixels[i],
                static_cast<size_t>(texture_layer_byte_size));
     }
-    vkUnmapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory);
+    vkUnmapMemory(_device, inefficient_staging_buffer_memory);
 
     // layout transitions -- image layout is set from none to destination
     PVulkanUtil::transitionImageLayout(&m_vulkan_context,
@@ -683,12 +690,12 @@ void Pilot::PVulkanManager::initializeCubeMap(VkImage&             image,
                                    static_cast<uint32_t>(texture_image_height),
                                    6);
 
-    vkDestroyBuffer(m_vulkan_context._device, inefficient_staging_buffer, nullptr);
-    vkFreeMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, nullptr);
+    vkDestroyBuffer(_device, inefficient_staging_buffer, nullptr);
+    vkFreeMemory(_device, inefficient_staging_buffer_memory, nullptr);
 
     generateTextureMipMaps(image, vulkan_image_format, texture_image_width, texture_image_height, 6, miplevels);
 
-    image_view = PVulkanUtil::createImageView(m_vulkan_context._device,
+    image_view = PVulkanUtil::createImageView(_device,
                                               image,
                                               vulkan_image_format,
                                               VK_IMAGE_ASPECT_COLOR_BIT,
@@ -706,6 +713,8 @@ bool Pilot::PVulkanManager::initializeTextureImage(VkImage&           image,
                                                    PILOT_PIXEL_FORMAT texture_image_format,
                                                    uint32_t           miplevels)
 {
+    auto& _device          = m_vulkan_context._device;
+    auto& _physical_device = m_vulkan_context._physical_device;
     if (!texture_image_pixels)
     {
         return false;
@@ -751,8 +760,8 @@ bool Pilot::PVulkanManager::initializeTextureImage(VkImage&           image,
     // use staging buffer
     VkBuffer       inefficient_staging_buffer;
     VkDeviceMemory inefficient_staging_buffer_memory;
-    PVulkanUtil::createBuffer(m_vulkan_context._physical_device,
-                              m_vulkan_context._device,
+    PVulkanUtil::createBuffer(_physical_device,
+                              _device,
                               texture_byte_size,
                               VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                               VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -760,9 +769,9 @@ bool Pilot::PVulkanManager::initializeTextureImage(VkImage&           image,
                               inefficient_staging_buffer_memory);
 
     void* data;
-    vkMapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, 0, texture_byte_size, 0, &data);
+    vkMapMemory(_device, inefficient_staging_buffer_memory, 0, texture_byte_size, 0, &data);
     memcpy(data, texture_image_pixels, static_cast<size_t>(texture_byte_size));
-    vkUnmapMemory(m_vulkan_context._device, inefficient_staging_buffer_memory);
+    vkUnmapMemory(_device, inefficient_staging_buffer_memory);
 
     // generate mipmapped image
     uint32_t mip_levels =
@@ -811,13 +820,13 @@ bool Pilot::PVulkanManager::initializeTextureImage(VkImage&           image,
                                        1,
                                        VK_IMAGE_ASPECT_COLOR_BIT);
 
-    vkDestroyBuffer(m_vulkan_context._device, inefficient_staging_buffer, nullptr);
-    vkFreeMemory(m_vulkan_context._device, inefficient_staging_buffer_memory, nullptr);
+    vkDestroyBuffer(_device, inefficient_staging_buffer, nullptr);
+    vkFreeMemory(_device, inefficient_staging_buffer_memory, nullptr);
 
     // generate mipmapped image
     PVulkanUtil::genMipmappedImage(&m_vulkan_context, image, texture_image_width, texture_image_height, mip_levels);
 
-    image_view = PVulkanUtil::createImageView(m_vulkan_context._device,
+    image_view = PVulkanUtil::createImageView(_device,
                                               image,
                                               vulkan_image_format,
                                               VK_IMAGE_ASPECT_COLOR_BIT,

--- a/engine/source/runtime/function/render/source/vulkan_manager/passes/color_grading.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/passes/color_grading.cpp
@@ -9,17 +9,18 @@
 
 namespace Pilot
 {
-    void PColorGradingPass::initialize(VkRenderPass render_pass, VkImageView input_attachment)
+    void PColorGradingPass::initialize(VkRenderPass render_pass)
     {
         _framebuffer.render_pass = render_pass;
         setupDescriptorSetLayout();
         setupPipelines();
         setupDescriptorSet();
-        updateAfterFramebufferRecreate(input_attachment);
+        updateAfterFramebufferRecreate();
     }
 
     void PColorGradingPass::setupDescriptorSetLayout()
     {
+        auto& _device = m_p_vulkan_context->_device;
         _descriptor_infos.resize(1);
 
         VkDescriptorSetLayoutBinding post_process_global_layout_bindings[2] = {};
@@ -42,10 +43,10 @@ namespace Pilot
         post_process_global_layout_create_info.pNext = NULL;
         post_process_global_layout_create_info.flags = 0;
         post_process_global_layout_create_info.bindingCount =
-            sizeof(post_process_global_layout_bindings) / sizeof(post_process_global_layout_bindings[0]);
+            std::size(post_process_global_layout_bindings);
         post_process_global_layout_create_info.pBindings = post_process_global_layout_bindings;
 
-        if (VK_SUCCESS != vkCreateDescriptorSetLayout(m_p_vulkan_context->_device,
+        if (VK_SUCCESS != vkCreateDescriptorSetLayout(_device,
                                                       &post_process_global_layout_create_info,
                                                       NULL,
                                                       &_descriptor_infos[0].layout))
@@ -56,6 +57,7 @@ namespace Pilot
 
     void PColorGradingPass::setupPipelines()
     {
+        auto& _device = m_p_vulkan_context->_device;
         _render_pipelines.resize(1);
 
         VkDescriptorSetLayout      descriptorset_layouts[1] = {_descriptor_infos[0].layout};
@@ -65,31 +67,14 @@ namespace Pilot
         pipeline_layout_create_info.pSetLayouts    = descriptorset_layouts;
 
         if (vkCreatePipelineLayout(
-                m_p_vulkan_context->_device, &pipeline_layout_create_info, nullptr, &_render_pipelines[0].layout) !=
+                _device, &pipeline_layout_create_info, nullptr, &_render_pipelines[0].layout) !=
             VK_SUCCESS)
         {
             throw std::runtime_error("create post process pipeline layout");
         }
 
-        VkShaderModule vert_shader_module =
-            PVulkanUtil::createShaderModule(m_p_vulkan_context->_device, POST_PROCESS_VERT);
-        VkShaderModule frag_shader_module =
-            PVulkanUtil::createShaderModule(m_p_vulkan_context->_device, COLOR_GRADING_FRAG);
-
-        VkPipelineShaderStageCreateInfo vert_pipeline_shader_stage_create_info {};
-        vert_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        vert_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_VERTEX_BIT;
-        vert_pipeline_shader_stage_create_info.module = vert_shader_module;
-        vert_pipeline_shader_stage_create_info.pName  = "main";
-
-        VkPipelineShaderStageCreateInfo frag_pipeline_shader_stage_create_info {};
-        frag_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        frag_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
-        frag_pipeline_shader_stage_create_info.module = frag_shader_module;
-        frag_pipeline_shader_stage_create_info.pName  = "main";
-
-        VkPipelineShaderStageCreateInfo shader_stages[] = {vert_pipeline_shader_stage_create_info,
-                                                           frag_pipeline_shader_stage_create_info};
+        VkPipelineShaderStageCreateInfo shader_stages[2] = {};
+        FillShaderStageCreateInfo(shader_stages, _device, POST_PROCESS_VERT, COLOR_GRADING_FRAG);
 
         VkPipelineVertexInputStateCreateInfo vertex_input_state_create_info {};
         vertex_input_state_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
@@ -106,9 +91,9 @@ namespace Pilot
         VkPipelineViewportStateCreateInfo viewport_state_create_info {};
         viewport_state_create_info.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
         viewport_state_create_info.viewportCount = 1;
-        viewport_state_create_info.pViewports    = &m_command_info._viewport;
+        viewport_state_create_info.pViewports    = NULL;
         viewport_state_create_info.scissorCount  = 1;
-        viewport_state_create_info.pScissors     = &m_command_info._scissor;
+        viewport_state_create_info.pScissors     = NULL;
 
         VkPipelineRasterizationStateCreateInfo rasterization_state_create_info {};
         rasterization_state_create_info.sType            = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
@@ -132,12 +117,6 @@ namespace Pilot
         color_blend_attachment_state.colorWriteMask =
             VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         color_blend_attachment_state.blendEnable         = VK_FALSE;
-        color_blend_attachment_state.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
-        color_blend_attachment_state.dstColorBlendFactor = VK_BLEND_FACTOR_ZERO;
-        color_blend_attachment_state.colorBlendOp        = VK_BLEND_OP_ADD;
-        color_blend_attachment_state.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-        color_blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-        color_blend_attachment_state.alphaBlendOp        = VK_BLEND_OP_ADD;
 
         VkPipelineColorBlendStateCreateInfo color_blend_state_create_info {};
         color_blend_state_create_info.sType             = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
@@ -162,7 +141,7 @@ namespace Pilot
 
         VkPipelineDynamicStateCreateInfo dynamic_state_create_info {};
         dynamic_state_create_info.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-        dynamic_state_create_info.dynamicStateCount = 2;
+        dynamic_state_create_info.dynamicStateCount = std::size(dynamic_states);
         dynamic_state_create_info.pDynamicStates    = dynamic_states;
 
         VkGraphicsPipelineCreateInfo pipelineInfo {};
@@ -182,7 +161,7 @@ namespace Pilot
         pipelineInfo.basePipelineHandle  = VK_NULL_HANDLE;
         pipelineInfo.pDynamicState       = &dynamic_state_create_info;
 
-        if (vkCreateGraphicsPipelines(m_p_vulkan_context->_device,
+        if (vkCreateGraphicsPipelines(_device,
                                       VK_NULL_HANDLE,
                                       1,
                                       &pipelineInfo,
@@ -192,12 +171,12 @@ namespace Pilot
             throw std::runtime_error("create post process graphics pipeline");
         }
 
-        vkDestroyShaderModule(m_p_vulkan_context->_device, vert_shader_module, nullptr);
-        vkDestroyShaderModule(m_p_vulkan_context->_device, frag_shader_module, nullptr);
+        ModuleGC();
     }
 
     void PColorGradingPass::setupDescriptorSet()
     {
+        auto&                       _device = m_p_vulkan_context->_device;
         VkDescriptorSetAllocateInfo post_process_global_descriptor_set_alloc_info;
         post_process_global_descriptor_set_alloc_info.sType          = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
         post_process_global_descriptor_set_alloc_info.pNext          = NULL;
@@ -205,7 +184,7 @@ namespace Pilot
         post_process_global_descriptor_set_alloc_info.descriptorSetCount = 1;
         post_process_global_descriptor_set_alloc_info.pSetLayouts        = &_descriptor_infos[0].layout;
 
-        if (VK_SUCCESS != vkAllocateDescriptorSets(m_p_vulkan_context->_device,
+        if (VK_SUCCESS != vkAllocateDescriptorSets(_device,
                                                    &post_process_global_descriptor_set_alloc_info,
                                                    &_descriptor_infos[0].descriptor_set))
         {
@@ -213,17 +192,20 @@ namespace Pilot
         }
     }
 
-    void PColorGradingPass::updateAfterFramebufferRecreate(VkImageView input_attachment)
+    void PColorGradingPass::updateAfterFramebufferRecreate()
     {
+        auto&                 _device                                      = m_p_vulkan_context->_device;
+        auto&                 _physical_device                             = m_p_vulkan_context->_physical_device;
         VkDescriptorImageInfo post_process_per_frame_input_attachment_info = {};
         post_process_per_frame_input_attachment_info.sampler =
-            PVulkanUtil::getOrCreateNearestSampler(m_p_vulkan_context->_physical_device, m_p_vulkan_context->_device);
-        post_process_per_frame_input_attachment_info.imageView   = input_attachment;
+            PVulkanUtil::getOrCreateNearestSampler(_physical_device, _device);
+        post_process_per_frame_input_attachment_info.imageView = m_p_vulkan_context->GetImageView(
+            std::hash<_main_camera_pass_buffer>()(_main_camera_pass_backup_buffer_even));
         post_process_per_frame_input_attachment_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
         VkDescriptorImageInfo color_grading_LUT_image_info = {};
         color_grading_LUT_image_info.sampler =
-            PVulkanUtil::getOrCreateLinearSampler(m_p_vulkan_context->_physical_device, m_p_vulkan_context->_device);
+            PVulkanUtil::getOrCreateLinearSampler(_physical_device, _device);
         color_grading_LUT_image_info.imageView =
             m_p_global_render_resource->_color_grading_resource._color_grading_LUT_texture_image_view;
         color_grading_LUT_image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -251,9 +233,8 @@ namespace Pilot
         post_process_descriptor_LUT_write_info.descriptorCount       = 1;
         post_process_descriptor_LUT_write_info.pImageInfo            = &color_grading_LUT_image_info;
 
-        vkUpdateDescriptorSets(m_p_vulkan_context->_device,
-                               sizeof(post_process_descriptor_writes_info) /
-                                   sizeof(post_process_descriptor_writes_info[0]),
+        vkUpdateDescriptorSets(_device,
+                               std::size(post_process_descriptor_writes_info),
                                post_process_descriptor_writes_info,
                                0,
                                NULL);
@@ -261,18 +242,19 @@ namespace Pilot
 
     void PColorGradingPass::draw()
     {
+        auto& command_buffer = m_command_info._current_command_buffer;
         if (m_render_config._enable_debug_untils_label)
         {
             VkDebugUtilsLabelEXT label_info = {
                 VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "Color Grading", {1.0f, 1.0f, 1.0f, 1.0f}};
-            m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(m_command_info._current_command_buffer, &label_info);
+            m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(command_buffer, &label_info);
         }
 
         m_p_vulkan_context->_vkCmdBindPipeline(
-            m_command_info._current_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, _render_pipelines[0].pipeline);
-        m_p_vulkan_context->_vkCmdSetViewport(m_command_info._current_command_buffer, 0, 1, &m_command_info._viewport);
-        m_p_vulkan_context->_vkCmdSetScissor(m_command_info._current_command_buffer, 0, 1, &m_command_info._scissor);
-        m_p_vulkan_context->_vkCmdBindDescriptorSets(m_command_info._current_command_buffer,
+            command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, _render_pipelines[0].pipeline);
+        m_p_vulkan_context->_vkCmdSetViewport(command_buffer, 0, 1, &m_command_info._viewport);
+        m_p_vulkan_context->_vkCmdSetScissor(command_buffer, 0, 1, &m_command_info._scissor);
+        m_p_vulkan_context->_vkCmdBindDescriptorSets(command_buffer,
                                                      VK_PIPELINE_BIND_POINT_GRAPHICS,
                                                      _render_pipelines[0].layout,
                                                      0,
@@ -281,11 +263,11 @@ namespace Pilot
                                                      0,
                                                      NULL);
 
-        vkCmdDraw(m_command_info._current_command_buffer, 3, 1, 0, 0);
+        vkCmdDraw(command_buffer, 3, 1, 0, 0);
 
         if (m_render_config._enable_debug_untils_label)
         {
-            m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(m_command_info._current_command_buffer);
+            m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(command_buffer);
         }
     }
 

--- a/engine/source/runtime/function/render/source/vulkan_manager/passes/combine_ui.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/passes/combine_ui.cpp
@@ -22,6 +22,7 @@ namespace Pilot
 
     void PCombineUIPass::setupDescriptorSetLayout()
     {
+        auto& _device = m_p_vulkan_context->_device;
         _descriptor_infos.resize(1);
 
         VkDescriptorSetLayoutBinding post_process_global_layout_bindings[2] = {};
@@ -41,17 +42,14 @@ namespace Pilot
         global_layout_normal_input_attachment_binding.stageFlags      = VK_SHADER_STAGE_FRAGMENT_BIT;
 
         VkDescriptorSetLayoutCreateInfo post_process_global_layout_create_info;
-        post_process_global_layout_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        post_process_global_layout_create_info.pNext = NULL;
-        post_process_global_layout_create_info.flags = 0;
-        post_process_global_layout_create_info.bindingCount =
-            sizeof(post_process_global_layout_bindings) / sizeof(post_process_global_layout_bindings[0]);
-        post_process_global_layout_create_info.pBindings = post_process_global_layout_bindings;
+        post_process_global_layout_create_info.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        post_process_global_layout_create_info.pNext        = NULL;
+        post_process_global_layout_create_info.flags        = 0;
+        post_process_global_layout_create_info.bindingCount = std::size(post_process_global_layout_bindings);
+        post_process_global_layout_create_info.pBindings    = post_process_global_layout_bindings;
 
-        if (VK_SUCCESS != vkCreateDescriptorSetLayout(m_p_vulkan_context->_device,
-                                                      &post_process_global_layout_create_info,
-                                                      NULL,
-                                                      &_descriptor_infos[0].layout))
+        if (VK_SUCCESS != vkCreateDescriptorSetLayout(
+                              _device, &post_process_global_layout_create_info, NULL, &_descriptor_infos[0].layout))
         {
             throw std::runtime_error("create combine ui global layout");
         }
@@ -59,6 +57,7 @@ namespace Pilot
 
     void PCombineUIPass::setupPipelines()
     {
+        auto& _device = m_p_vulkan_context->_device;
         _render_pipelines.resize(1);
 
         VkDescriptorSetLayout      descriptorset_layouts[1] = {_descriptor_infos[0].layout};
@@ -67,32 +66,14 @@ namespace Pilot
         pipeline_layout_create_info.setLayoutCount = 1;
         pipeline_layout_create_info.pSetLayouts    = descriptorset_layouts;
 
-        if (vkCreatePipelineLayout(
-                m_p_vulkan_context->_device, &pipeline_layout_create_info, nullptr, &_render_pipelines[0].layout) !=
+        if (vkCreatePipelineLayout(_device, &pipeline_layout_create_info, nullptr, &_render_pipelines[0].layout) !=
             VK_SUCCESS)
         {
             throw std::runtime_error("create combine ui pipeline layout");
         }
 
-        VkShaderModule vert_shader_module =
-            PVulkanUtil::createShaderModule(m_p_vulkan_context->_device, POST_PROCESS_VERT);
-        VkShaderModule frag_shader_module =
-            PVulkanUtil::createShaderModule(m_p_vulkan_context->_device, COMBINE_UI_FRAG);
-
-        VkPipelineShaderStageCreateInfo vert_pipeline_shader_stage_create_info {};
-        vert_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        vert_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_VERTEX_BIT;
-        vert_pipeline_shader_stage_create_info.module = vert_shader_module;
-        vert_pipeline_shader_stage_create_info.pName  = "main";
-
-        VkPipelineShaderStageCreateInfo frag_pipeline_shader_stage_create_info {};
-        frag_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        frag_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
-        frag_pipeline_shader_stage_create_info.module = frag_shader_module;
-        frag_pipeline_shader_stage_create_info.pName  = "main";
-
-        VkPipelineShaderStageCreateInfo shader_stages[] = {vert_pipeline_shader_stage_create_info,
-                                                           frag_pipeline_shader_stage_create_info};
+        VkPipelineShaderStageCreateInfo shader_stages[2] = {};
+        FillShaderStageCreateInfo(shader_stages, _device, POST_PROCESS_VERT, COMBINE_UI_FRAG);
 
         VkPipelineVertexInputStateCreateInfo vertex_input_state_create_info {};
         vertex_input_state_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
@@ -109,9 +90,9 @@ namespace Pilot
         VkPipelineViewportStateCreateInfo viewport_state_create_info {};
         viewport_state_create_info.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
         viewport_state_create_info.viewportCount = 1;
-        viewport_state_create_info.pViewports    = &m_command_info._viewport;
+        viewport_state_create_info.pViewports    = NULL;
         viewport_state_create_info.scissorCount  = 1;
-        viewport_state_create_info.pScissors     = &m_command_info._scissor;
+        viewport_state_create_info.pScissors     = NULL;
 
         VkPipelineRasterizationStateCreateInfo rasterization_state_create_info {};
         rasterization_state_create_info.sType            = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
@@ -135,12 +116,6 @@ namespace Pilot
         color_blend_attachment_state.colorWriteMask =
             VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         color_blend_attachment_state.blendEnable         = VK_FALSE;
-        color_blend_attachment_state.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
-        color_blend_attachment_state.dstColorBlendFactor = VK_BLEND_FACTOR_ZERO;
-        color_blend_attachment_state.colorBlendOp        = VK_BLEND_OP_ADD;
-        color_blend_attachment_state.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-        color_blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-        color_blend_attachment_state.alphaBlendOp        = VK_BLEND_OP_ADD;
 
         VkPipelineColorBlendStateCreateInfo color_blend_state_create_info {};
         color_blend_state_create_info.sType             = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
@@ -165,12 +140,12 @@ namespace Pilot
 
         VkPipelineDynamicStateCreateInfo dynamic_state_create_info {};
         dynamic_state_create_info.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-        dynamic_state_create_info.dynamicStateCount = 2;
+        dynamic_state_create_info.dynamicStateCount = std::size(dynamic_states);
         dynamic_state_create_info.pDynamicStates    = dynamic_states;
 
         VkGraphicsPipelineCreateInfo pipelineInfo {};
         pipelineInfo.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-        pipelineInfo.stageCount          = 2;
+        pipelineInfo.stageCount          = std::size(shader_stages);
         pipelineInfo.pStages             = shader_stages;
         pipelineInfo.pVertexInputState   = &vertex_input_state_create_info;
         pipelineInfo.pInputAssemblyState = &input_assembly_create_info;
@@ -185,22 +160,18 @@ namespace Pilot
         pipelineInfo.basePipelineHandle  = VK_NULL_HANDLE;
         pipelineInfo.pDynamicState       = &dynamic_state_create_info;
 
-        if (vkCreateGraphicsPipelines(m_p_vulkan_context->_device,
-                                      VK_NULL_HANDLE,
-                                      1,
-                                      &pipelineInfo,
-                                      nullptr,
-                                      &_render_pipelines[0].pipeline) != VK_SUCCESS)
+        if (vkCreateGraphicsPipelines(
+                _device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &_render_pipelines[0].pipeline) != VK_SUCCESS)
         {
             throw std::runtime_error("create post process graphics pipeline");
         }
 
-        vkDestroyShaderModule(m_p_vulkan_context->_device, vert_shader_module, nullptr);
-        vkDestroyShaderModule(m_p_vulkan_context->_device, frag_shader_module, nullptr);
+        ModuleGC();
     }
 
     void PCombineUIPass::setupDescriptorSet()
     {
+        auto&                       _device = m_p_vulkan_context->_device;
         VkDescriptorSetAllocateInfo post_process_global_descriptor_set_alloc_info;
         post_process_global_descriptor_set_alloc_info.sType          = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
         post_process_global_descriptor_set_alloc_info.pNext          = NULL;
@@ -208,7 +179,7 @@ namespace Pilot
         post_process_global_descriptor_set_alloc_info.descriptorSetCount = 1;
         post_process_global_descriptor_set_alloc_info.pSetLayouts        = &_descriptor_infos[0].layout;
 
-        if (VK_SUCCESS != vkAllocateDescriptorSets(m_p_vulkan_context->_device,
+        if (VK_SUCCESS != vkAllocateDescriptorSets(_device,
                                                    &post_process_global_descriptor_set_alloc_info,
                                                    &_descriptor_infos[0].descriptor_set))
         {
@@ -219,15 +190,16 @@ namespace Pilot
     void PCombineUIPass::updateAfterFramebufferRecreate(VkImageView scene_input_attachment,
                                                         VkImageView ui_input_attachment)
     {
+        auto&                 _device                               = m_p_vulkan_context->_device;
+        auto&                 _physical_device                      = m_p_vulkan_context->_physical_device;
         VkDescriptorImageInfo per_frame_scene_input_attachment_info = {};
         per_frame_scene_input_attachment_info.sampler =
-            PVulkanUtil::getOrCreateNearestSampler(m_p_vulkan_context->_physical_device, m_p_vulkan_context->_device);
+            PVulkanUtil::getOrCreateNearestSampler(_physical_device, _device);
         per_frame_scene_input_attachment_info.imageView   = scene_input_attachment;
         per_frame_scene_input_attachment_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
         VkDescriptorImageInfo per_frame_ui_input_attachment_info = {};
-        per_frame_ui_input_attachment_info.sampler =
-            PVulkanUtil::getOrCreateNearestSampler(m_p_vulkan_context->_physical_device, m_p_vulkan_context->_device);
+        per_frame_ui_input_attachment_info.sampler = PVulkanUtil::getOrCreateNearestSampler(_physical_device, _device);
         per_frame_ui_input_attachment_info.imageView   = ui_input_attachment;
         per_frame_ui_input_attachment_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
@@ -253,21 +225,18 @@ namespace Pilot
         per_frame_ui_input_attachment_write_info.descriptorCount       = 1;
         per_frame_ui_input_attachment_write_info.pImageInfo            = &per_frame_ui_input_attachment_info;
 
-        vkUpdateDescriptorSets(m_p_vulkan_context->_device,
-                               sizeof(post_process_descriptor_writes_info) /
-                                   sizeof(post_process_descriptor_writes_info[0]),
-                               post_process_descriptor_writes_info,
-                               0,
-                               NULL);
+        vkUpdateDescriptorSets(
+            _device, std::size(post_process_descriptor_writes_info), post_process_descriptor_writes_info, 0, NULL);
     }
 
     void PCombineUIPass::draw()
     {
+        auto& command_buffer = m_command_info._current_command_buffer;
         if (m_render_config._enable_debug_untils_label)
         {
             VkDebugUtilsLabelEXT label_info = {
                 VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "Combine UI", {1.0f, 1.0f, 1.0f, 1.0f}};
-            m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(m_command_info._current_command_buffer, &label_info);
+            m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(command_buffer, &label_info);
         }
 
         VkViewport viewport = {0.0,
@@ -280,10 +249,10 @@ namespace Pilot
             0, 0, m_p_vulkan_context->_swapchain_extent.width, m_p_vulkan_context->_swapchain_extent.height};
 
         m_p_vulkan_context->_vkCmdBindPipeline(
-            m_command_info._current_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, _render_pipelines[0].pipeline);
-        m_p_vulkan_context->_vkCmdSetViewport(m_command_info._current_command_buffer, 0, 1, &viewport);
-        m_p_vulkan_context->_vkCmdSetScissor(m_command_info._current_command_buffer, 0, 1, &scissor);
-        m_p_vulkan_context->_vkCmdBindDescriptorSets(m_command_info._current_command_buffer,
+            command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, _render_pipelines[0].pipeline);
+        m_p_vulkan_context->_vkCmdSetViewport(command_buffer, 0, 1, &viewport);
+        m_p_vulkan_context->_vkCmdSetScissor(command_buffer, 0, 1, &scissor);
+        m_p_vulkan_context->_vkCmdBindDescriptorSets(command_buffer,
                                                      VK_PIPELINE_BIND_POINT_GRAPHICS,
                                                      _render_pipelines[0].layout,
                                                      0,
@@ -292,11 +261,11 @@ namespace Pilot
                                                      0,
                                                      NULL);
 
-        vkCmdDraw(m_command_info._current_command_buffer, 3, 1, 0, 0);
+        vkCmdDraw(command_buffer, 3, 1, 0, 0);
 
         if (m_render_config._enable_debug_untils_label)
         {
-            m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(m_command_info._current_command_buffer);
+            m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(command_buffer);
         }
     }
 

--- a/engine/source/runtime/function/render/source/vulkan_manager/passes/point_light_shadow.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/passes/point_light_shadow.cpp
@@ -14,7 +14,7 @@ namespace Pilot
 {
     void PPointLightShadowPass::initialize()
     {
-        setupAttachments();
+        createImage();
         setupRenderPass();
         setupFramebuffer();
         setupDescriptorSetLayout();
@@ -26,93 +26,67 @@ namespace Pilot
     }
     void PPointLightShadowPass::draw()
     {
+        auto& command_buffer = m_command_info._current_command_buffer;
         if (m_render_config._enable_debug_untils_label)
         {
             VkDebugUtilsLabelEXT label_info = {
                 VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "Point Light Shadow", {1.0f, 1.0f, 1.0f, 1.0f}};
-            m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(m_command_info._current_command_buffer, &label_info);
+            m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(command_buffer, &label_info);
         }
 
         drawModel();
 
         if (m_render_config._enable_debug_untils_label)
         {
-            m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(m_command_info._current_command_buffer);
+            m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(command_buffer);
         }
     }
-    void PPointLightShadowPass::setupAttachments()
+    void PPointLightShadowPass::createImage()
     {
-        // color and depth
-        _framebuffer.attachments.resize(2);
+        m_p_vulkan_context->CreateRenderImage2D(std::hash<std::string>()("point shadow color"),
+                                                VK_FORMAT_R32_SFLOAT,
+                                                m_point_light_shadow_map_dimension,
+                                                m_point_light_shadow_map_dimension,
+                                                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                                                VK_IMAGE_ASPECT_COLOR_BIT,
+                                                2 * m_max_point_light_count,
+                                                1);
 
-        // color
-        _framebuffer.attachments[0].format = VK_FORMAT_R32_SFLOAT;
-        PVulkanUtil::createImage(m_p_vulkan_context->_physical_device,
-                                 m_p_vulkan_context->_device,
-                                 m_point_light_shadow_map_dimension,
-                                 m_point_light_shadow_map_dimension,
-                                 _framebuffer.attachments[0].format,
-                                 VK_IMAGE_TILING_OPTIMAL,
-                                 VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-                                 VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                 _framebuffer.attachments[0].image,
-                                 _framebuffer.attachments[0].mem,
-                                 0,
-                                 2 * m_max_point_light_count,
-                                 1);
-        _framebuffer.attachments[0].view = PVulkanUtil::createImageView(m_p_vulkan_context->_device,
-                                                                        _framebuffer.attachments[0].image,
-                                                                        _framebuffer.attachments[0].format,
-                                                                        VK_IMAGE_ASPECT_COLOR_BIT,
-                                                                        VK_IMAGE_VIEW_TYPE_2D_ARRAY,
-                                                                        2 * m_max_point_light_count,
-                                                                        1);
-
-        // depth
-        _framebuffer.attachments[1].format = m_p_vulkan_context->_depth_image_format;
-        PVulkanUtil::createImage(m_p_vulkan_context->_physical_device,
-                                 m_p_vulkan_context->_device,
-                                 m_point_light_shadow_map_dimension,
-                                 m_point_light_shadow_map_dimension,
-                                 _framebuffer.attachments[1].format,
-                                 VK_IMAGE_TILING_OPTIMAL,
-                                 VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT,
-                                 VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                 _framebuffer.attachments[1].image,
-                                 _framebuffer.attachments[1].mem,
-                                 0,
-                                 2 * m_max_point_light_count,
-                                 1);
-        _framebuffer.attachments[1].view = PVulkanUtil::createImageView(m_p_vulkan_context->_device,
-                                                                        _framebuffer.attachments[1].image,
-                                                                        _framebuffer.attachments[1].format,
-                                                                        VK_IMAGE_ASPECT_DEPTH_BIT,
-                                                                        VK_IMAGE_VIEW_TYPE_2D_ARRAY,
-                                                                        2 * m_max_point_light_count,
-                                                                        1);
+        m_p_vulkan_context->CreateRenderImage2D(std::hash<std::string>()("point shadow depth"),
+                                                m_p_vulkan_context->_depth_image_format,
+                                                m_point_light_shadow_map_dimension,
+                                                m_point_light_shadow_map_dimension,
+                                                VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                                                    VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT,
+                                                VK_IMAGE_ASPECT_DEPTH_BIT,
+                                                2 * m_max_point_light_count,
+                                                1);
     }
     void PPointLightShadowPass::setupRenderPass()
     {
+        auto&                   _device        = m_p_vulkan_context->_device;
         VkAttachmentDescription attachments[2] = {};
 
         VkAttachmentDescription& point_light_shadow_color_attachment_description = attachments[0];
-        point_light_shadow_color_attachment_description.format                   = _framebuffer.attachments[0].format;
-        point_light_shadow_color_attachment_description.samples                  = VK_SAMPLE_COUNT_1_BIT;
-        point_light_shadow_color_attachment_description.loadOp                   = VK_ATTACHMENT_LOAD_OP_CLEAR;
-        point_light_shadow_color_attachment_description.storeOp                  = VK_ATTACHMENT_STORE_OP_STORE;
-        point_light_shadow_color_attachment_description.stencilLoadOp            = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-        point_light_shadow_color_attachment_description.stencilStoreOp           = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        point_light_shadow_color_attachment_description.initialLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
-        point_light_shadow_color_attachment_description.finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        point_light_shadow_color_attachment_description.format =
+            m_p_vulkan_context->GetImageFormat(std::hash<std::string>()("point shadow color"));
+        point_light_shadow_color_attachment_description.samples        = VK_SAMPLE_COUNT_1_BIT;
+        point_light_shadow_color_attachment_description.loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        point_light_shadow_color_attachment_description.storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
+        point_light_shadow_color_attachment_description.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        point_light_shadow_color_attachment_description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        point_light_shadow_color_attachment_description.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+        point_light_shadow_color_attachment_description.finalLayout    = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
         VkAttachmentDescription& point_light_shadow_depth_attachment_description = attachments[1];
-        point_light_shadow_depth_attachment_description.format                   = _framebuffer.attachments[1].format;
-        point_light_shadow_depth_attachment_description.samples                  = VK_SAMPLE_COUNT_1_BIT;
-        point_light_shadow_depth_attachment_description.loadOp                   = VK_ATTACHMENT_LOAD_OP_CLEAR;
-        point_light_shadow_depth_attachment_description.storeOp                  = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        point_light_shadow_depth_attachment_description.stencilLoadOp            = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-        point_light_shadow_depth_attachment_description.stencilStoreOp           = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        point_light_shadow_depth_attachment_description.initialLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
+        point_light_shadow_depth_attachment_description.format =
+            m_p_vulkan_context->GetImageFormat(std::hash<std::string>()("point shadow depth"));
+        point_light_shadow_depth_attachment_description.samples        = VK_SAMPLE_COUNT_1_BIT;
+        point_light_shadow_depth_attachment_description.loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        point_light_shadow_depth_attachment_description.storeOp        = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        point_light_shadow_depth_attachment_description.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        point_light_shadow_depth_attachment_description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        point_light_shadow_depth_attachment_description.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
         point_light_shadow_depth_attachment_description.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
         VkSubpassDescription subpasses[1] = {};
@@ -146,42 +120,42 @@ namespace Pilot
 
         VkRenderPassCreateInfo renderpass_create_info {};
         renderpass_create_info.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-        renderpass_create_info.attachmentCount = (sizeof(attachments) / sizeof(attachments[0]));
+        renderpass_create_info.attachmentCount = std::size(attachments);
         renderpass_create_info.pAttachments    = attachments;
-        renderpass_create_info.subpassCount    = (sizeof(subpasses) / sizeof(subpasses[0]));
+        renderpass_create_info.subpassCount    = std::size(subpasses);
         renderpass_create_info.pSubpasses      = subpasses;
-        renderpass_create_info.dependencyCount = (sizeof(dependencies) / sizeof(dependencies[0]));
+        renderpass_create_info.dependencyCount = std::size(dependencies);
         renderpass_create_info.pDependencies   = dependencies;
 
-        if (vkCreateRenderPass(
-                m_p_vulkan_context->_device, &renderpass_create_info, nullptr, &_framebuffer.render_pass) != VK_SUCCESS)
+        if (vkCreateRenderPass(_device, &renderpass_create_info, nullptr, &_framebuffer.render_pass) != VK_SUCCESS)
         {
             throw std::runtime_error("create point light shadow render pass");
         }
     }
     void PPointLightShadowPass::setupFramebuffer()
     {
-        VkImageView attachments[2] = {_framebuffer.attachments[0].view, _framebuffer.attachments[1].view};
+        auto&       _device        = m_p_vulkan_context->_device;
+        VkImageView attachments[2] = {m_p_vulkan_context->GetImageView(std::hash<std::string>()("point shadow color")),
+                                      m_p_vulkan_context->GetImageView(std::hash<std::string>()("point shadow depth"))};
 
         VkFramebufferCreateInfo framebuffer_create_info {};
         framebuffer_create_info.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
         framebuffer_create_info.flags           = 0U;
         framebuffer_create_info.renderPass      = _framebuffer.render_pass;
-        framebuffer_create_info.attachmentCount = (sizeof(attachments) / sizeof(attachments[0]));
+        framebuffer_create_info.attachmentCount = std::size(attachments);
         framebuffer_create_info.pAttachments    = attachments;
         framebuffer_create_info.width           = m_point_light_shadow_map_dimension;
         framebuffer_create_info.height          = m_point_light_shadow_map_dimension;
         framebuffer_create_info.layers          = 2 * m_max_point_light_count;
 
-        if (vkCreateFramebuffer(
-                m_p_vulkan_context->_device, &framebuffer_create_info, nullptr, &_framebuffer.framebuffer) !=
-            VK_SUCCESS)
+        if (vkCreateFramebuffer(_device, &framebuffer_create_info, nullptr, &_framebuffer.framebuffer) != VK_SUCCESS)
         {
             throw std::runtime_error("create point light shadow framebuffer");
         }
     }
     void PPointLightShadowPass::setupDescriptorSetLayout()
     {
+        auto& _device = m_p_vulkan_context->_device;
         _descriptor_infos.resize(1);
 
         VkDescriptorSetLayoutBinding mesh_point_light_shadow_global_layout_bindings[3];
@@ -223,16 +197,16 @@ namespace Pilot
              sizeof(mesh_point_light_shadow_global_layout_bindings[0]));
         mesh_point_light_shadow_global_layout_create_info.pBindings = mesh_point_light_shadow_global_layout_bindings;
 
-        if (VK_SUCCESS != vkCreateDescriptorSetLayout(m_p_vulkan_context->_device,
-                                                      &mesh_point_light_shadow_global_layout_create_info,
-                                                      NULL,
-                                                      &_descriptor_infos[0].layout))
+        if (VK_SUCCESS !=
+            vkCreateDescriptorSetLayout(
+                _device, &mesh_point_light_shadow_global_layout_create_info, NULL, &_descriptor_infos[0].layout))
         {
             throw std::runtime_error("create mesh point light shadow global layout");
         }
     }
     void PPointLightShadowPass::setupPipelines()
     {
+        auto& _device = m_p_vulkan_context->_device;
         if (!m_render_config._enable_point_light_shadow)
             return;
 
@@ -241,44 +215,21 @@ namespace Pilot
         VkDescriptorSetLayout      descriptorset_layouts[] = {_descriptor_infos[0].layout, _per_mesh_layout};
         VkPipelineLayoutCreateInfo pipeline_layout_create_info {};
         pipeline_layout_create_info.sType          = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-        pipeline_layout_create_info.setLayoutCount = (sizeof(descriptorset_layouts) / sizeof(descriptorset_layouts[0]));
+        pipeline_layout_create_info.setLayoutCount = std::size(descriptorset_layouts);
         pipeline_layout_create_info.pSetLayouts    = descriptorset_layouts;
 
-        if (vkCreatePipelineLayout(
-                m_p_vulkan_context->_device, &pipeline_layout_create_info, nullptr, &_render_pipelines[0].layout) !=
+        if (vkCreatePipelineLayout(_device, &pipeline_layout_create_info, nullptr, &_render_pipelines[0].layout) !=
             VK_SUCCESS)
         {
             throw std::runtime_error("create mesh point light shadow pipeline layout");
         }
 
-        VkShaderModule vert_shader_module =
-            PVulkanUtil::createShaderModule(m_p_vulkan_context->_device, MESH_POINT_LIGHT_SHADOW_VERT);
-        VkShaderModule geom_shader_module =
-            PVulkanUtil::createShaderModule(m_p_vulkan_context->_device, MESH_POINT_LIGHT_SHADOW_GEOM);
-        VkShaderModule frag_shader_module =
-            PVulkanUtil::createShaderModule(m_p_vulkan_context->_device, MESH_POINT_LIGHT_SHADOW_FRAG);
-
-        VkPipelineShaderStageCreateInfo vert_pipeline_shader_stage_create_info {};
-        vert_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        vert_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_VERTEX_BIT;
-        vert_pipeline_shader_stage_create_info.module = vert_shader_module;
-        vert_pipeline_shader_stage_create_info.pName  = "main";
-
-        VkPipelineShaderStageCreateInfo geom_pipeline_shader_stage_create_info {};
-        geom_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        geom_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_GEOMETRY_BIT;
-        geom_pipeline_shader_stage_create_info.module = geom_shader_module;
-        geom_pipeline_shader_stage_create_info.pName  = "main";
-
-        VkPipelineShaderStageCreateInfo frag_pipeline_shader_stage_create_info {};
-        frag_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        frag_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
-        frag_pipeline_shader_stage_create_info.module = frag_shader_module;
-        frag_pipeline_shader_stage_create_info.pName  = "main";
-
-        VkPipelineShaderStageCreateInfo shader_stages[] = {vert_pipeline_shader_stage_create_info,
-                                                           geom_pipeline_shader_stage_create_info,
-                                                           frag_pipeline_shader_stage_create_info};
+        VkPipelineShaderStageCreateInfo shader_stages[3] = {};
+        FillShaderStageCreateInfo(shader_stages,
+                                  _device,
+                                  MESH_POINT_LIGHT_SHADOW_VERT,
+                                  MESH_POINT_LIGHT_SHADOW_GEOM,
+                                  MESH_POINT_LIGHT_SHADOW_FRAG);
 
         auto                                 vertex_binding_descriptions   = PMeshVertex::getBindingDescriptions();
         auto                                 vertex_attribute_descriptions = PMeshVertex::getAttributeDescriptions();
@@ -294,15 +245,12 @@ namespace Pilot
         input_assembly_create_info.topology               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
         input_assembly_create_info.primitiveRestartEnable = VK_FALSE;
 
-        VkViewport viewport = {0, 0, m_point_light_shadow_map_dimension, m_point_light_shadow_map_dimension, 0.0, 1.0};
-        VkRect2D   scissor  = {{0, 0}, {m_point_light_shadow_map_dimension, m_point_light_shadow_map_dimension}};
-
         VkPipelineViewportStateCreateInfo viewport_state_create_info {};
         viewport_state_create_info.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
         viewport_state_create_info.viewportCount = 1;
-        viewport_state_create_info.pViewports    = &m_command_info._viewport;
+        viewport_state_create_info.pViewports    = NULL;
         viewport_state_create_info.scissorCount  = 1;
-        viewport_state_create_info.pScissors     = &m_command_info._scissor;
+        viewport_state_create_info.pScissors     = NULL;
 
         VkPipelineRasterizationStateCreateInfo rasterization_state_create_info {};
         rasterization_state_create_info.sType            = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
@@ -327,12 +275,6 @@ namespace Pilot
         color_blend_attachment_state.colorWriteMask =
             VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         color_blend_attachment_state.blendEnable         = VK_FALSE;
-        color_blend_attachment_state.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
-        color_blend_attachment_state.dstColorBlendFactor = VK_BLEND_FACTOR_ZERO;
-        color_blend_attachment_state.colorBlendOp        = VK_BLEND_OP_ADD;
-        color_blend_attachment_state.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-        color_blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-        color_blend_attachment_state.alphaBlendOp        = VK_BLEND_OP_ADD;
 
         VkPipelineColorBlendStateCreateInfo color_blend_state_create_info {};
         color_blend_state_create_info.sType             = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
@@ -353,14 +295,15 @@ namespace Pilot
         depth_stencil_create_info.depthBoundsTestEnable = VK_FALSE;
         depth_stencil_create_info.stencilTestEnable     = VK_FALSE;
 
+        VkDynamicState                   dynamic_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
         VkPipelineDynamicStateCreateInfo dynamic_state_create_info {};
         dynamic_state_create_info.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-        dynamic_state_create_info.dynamicStateCount = 0;
-        dynamic_state_create_info.pDynamicStates    = NULL;
+        dynamic_state_create_info.dynamicStateCount = std::size(dynamic_states);
+        dynamic_state_create_info.pDynamicStates    = dynamic_states;
 
         VkGraphicsPipelineCreateInfo pipelineInfo {};
         pipelineInfo.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-        pipelineInfo.stageCount          = (sizeof(shader_stages) / sizeof(shader_stages[0]));
+        pipelineInfo.stageCount          = std::size(shader_stages);
         pipelineInfo.pStages             = shader_stages;
         pipelineInfo.pVertexInputState   = &vertex_input_state_create_info;
         pipelineInfo.pInputAssemblyState = &input_assembly_create_info;
@@ -375,22 +318,19 @@ namespace Pilot
         pipelineInfo.basePipelineHandle  = VK_NULL_HANDLE;
         pipelineInfo.pDynamicState       = &dynamic_state_create_info;
 
-        if (vkCreateGraphicsPipelines(m_p_vulkan_context->_device,
-                                      VK_NULL_HANDLE,
-                                      1,
-                                      &pipelineInfo,
-                                      nullptr,
-                                      &_render_pipelines[0].pipeline) != VK_SUCCESS)
+        if (vkCreateGraphicsPipelines(
+                _device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &_render_pipelines[0].pipeline) != VK_SUCCESS)
         {
             throw std::runtime_error("create mesh point light shadow graphics pipeline");
         }
 
-        vkDestroyShaderModule(m_p_vulkan_context->_device, vert_shader_module, nullptr);
-        vkDestroyShaderModule(m_p_vulkan_context->_device, geom_shader_module, nullptr);
-        vkDestroyShaderModule(m_p_vulkan_context->_device, frag_shader_module, nullptr);
+        ModuleGC();
     }
     void PPointLightShadowPass::setupDescriptorSet()
     {
+        auto& _device         = m_p_vulkan_context->_device;
+        auto& _storage_buffer = m_p_global_render_resource->_storage_buffer;
+
         VkDescriptorSetAllocateInfo mesh_point_light_shadow_global_descriptor_set_alloc_info;
         mesh_point_light_shadow_global_descriptor_set_alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
         mesh_point_light_shadow_global_descriptor_set_alloc_info.pNext = NULL;
@@ -398,7 +338,7 @@ namespace Pilot
         mesh_point_light_shadow_global_descriptor_set_alloc_info.descriptorSetCount = 1;
         mesh_point_light_shadow_global_descriptor_set_alloc_info.pSetLayouts        = &_descriptor_infos[0].layout;
 
-        if (VK_SUCCESS != vkAllocateDescriptorSets(m_p_vulkan_context->_device,
+        if (VK_SUCCESS != vkAllocateDescriptorSets(_device,
                                                    &mesh_point_light_shadow_global_descriptor_set_alloc_info,
                                                    &_descriptor_infos[0].descriptor_set))
         {
@@ -411,28 +351,25 @@ namespace Pilot
         // the range means the size actually used by the shader per draw call
         mesh_point_light_shadow_perframe_storage_buffer_info.range =
             sizeof(MeshPointLightShadowPerframeStorageBufferObject);
-        mesh_point_light_shadow_perframe_storage_buffer_info.buffer =
-            m_p_global_render_resource->_storage_buffer._global_upload_ringbuffer;
-        assert(mesh_point_light_shadow_perframe_storage_buffer_info.range <
-               m_p_global_render_resource->_storage_buffer._max_storage_buffer_range);
+        mesh_point_light_shadow_perframe_storage_buffer_info.buffer = _storage_buffer._global_upload_ringbuffer;
+        assert(mesh_point_light_shadow_perframe_storage_buffer_info.range < _storage_buffer._max_storage_buffer_range);
 
         VkDescriptorBufferInfo mesh_point_light_shadow_perdrawcall_storage_buffer_info = {};
         mesh_point_light_shadow_perdrawcall_storage_buffer_info.offset                 = 0;
         mesh_point_light_shadow_perdrawcall_storage_buffer_info.range =
             sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject);
-        mesh_point_light_shadow_perdrawcall_storage_buffer_info.buffer =
-            m_p_global_render_resource->_storage_buffer._global_upload_ringbuffer;
+        mesh_point_light_shadow_perdrawcall_storage_buffer_info.buffer = _storage_buffer._global_upload_ringbuffer;
         assert(mesh_point_light_shadow_perdrawcall_storage_buffer_info.range <
-               m_p_global_render_resource->_storage_buffer._max_storage_buffer_range);
+               _storage_buffer._max_storage_buffer_range);
 
         VkDescriptorBufferInfo mesh_point_light_shadow_per_drawcall_vertex_blending_storage_buffer_info = {};
         mesh_point_light_shadow_per_drawcall_vertex_blending_storage_buffer_info.offset                 = 0;
         mesh_point_light_shadow_per_drawcall_vertex_blending_storage_buffer_info.range =
             sizeof(MeshPointLightShadowPerdrawcallVertexBlendingStorageBufferObject);
         mesh_point_light_shadow_per_drawcall_vertex_blending_storage_buffer_info.buffer =
-            m_p_global_render_resource->_storage_buffer._global_upload_ringbuffer;
+            _storage_buffer._global_upload_ringbuffer;
         assert(mesh_point_light_shadow_per_drawcall_vertex_blending_storage_buffer_info.range <
-               m_p_global_render_resource->_storage_buffer._max_storage_buffer_range);
+               _storage_buffer._max_storage_buffer_range);
 
         VkDescriptorSet descriptor_set_to_write = _descriptor_infos[0].descriptor_set;
 
@@ -476,14 +413,12 @@ namespace Pilot
         mesh_point_light_shadow_per_drawcall_vertex_blending_storage_buffer_write_info.pBufferInfo =
             &mesh_point_light_shadow_per_drawcall_vertex_blending_storage_buffer_info;
 
-        vkUpdateDescriptorSets(m_p_vulkan_context->_device,
-                               (sizeof(descriptor_writes) / sizeof(descriptor_writes[0])),
-                               descriptor_writes,
-                               0,
-                               NULL);
+        vkUpdateDescriptorSets(_device, std::size(descriptor_writes), descriptor_writes, 0, NULL);
     }
     void Pilot::PPointLightShadowPass::drawModel()
     {
+        auto& command_buffer  = m_command_info._current_command_buffer;
+        auto& _storage_buffer = m_p_global_render_resource->_storage_buffer;
         struct PMeshNode
         {
             glm::mat4 model_matrix;
@@ -524,11 +459,10 @@ namespace Pilot
         VkClearValue clear_values[2];
         clear_values[0].color                 = {1.0f};
         clear_values[1].depthStencil          = {1.0f, 0};
-        renderpass_begin_info.clearValueCount = (sizeof(clear_values) / sizeof(clear_values[0]));
+        renderpass_begin_info.clearValueCount = std::size(clear_values);
         renderpass_begin_info.pClearValues    = clear_values;
 
-        m_p_vulkan_context->_vkCmdBeginRenderPass(
-            m_command_info._current_command_buffer, &renderpass_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        m_p_vulkan_context->_vkCmdBeginRenderPass(command_buffer, &renderpass_begin_info, VK_SUBPASS_CONTENTS_INLINE);
 
         if (m_render_config._enable_point_light_shadow)
         {
@@ -536,31 +470,31 @@ namespace Pilot
             {
                 VkDebugUtilsLabelEXT label_info = {
                     VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "Mesh", {1.0f, 1.0f, 1.0f, 1.0f}};
-                m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(m_command_info._current_command_buffer, &label_info);
+                m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(command_buffer, &label_info);
             }
 
             m_p_vulkan_context->_vkCmdBindPipeline(
-                m_command_info._current_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, _render_pipelines[0].pipeline);
+                command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, _render_pipelines[0].pipeline);
+
+            VkViewport viewport = {
+                0, 0, m_point_light_shadow_map_dimension, m_point_light_shadow_map_dimension, 0.0, 1.0};
+            VkRect2D scissor = {{0, 0}, {m_point_light_shadow_map_dimension, m_point_light_shadow_map_dimension}};
+            m_p_vulkan_context->_vkCmdSetViewport(command_buffer, 0, 1, &viewport);
+            m_p_vulkan_context->_vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 
             // perframe storage buffer
             uint32_t perframe_dynamic_offset =
-                roundUp(m_p_global_render_resource->_storage_buffer
-                            ._global_upload_ringbuffers_end[m_command_info._current_frame_index],
-                        m_p_global_render_resource->_storage_buffer._min_storage_buffer_offset_alignment);
-            m_p_global_render_resource->_storage_buffer
-                ._global_upload_ringbuffers_end[m_command_info._current_frame_index] =
+                roundUp(_storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index],
+                        _storage_buffer._min_storage_buffer_offset_alignment);
+            _storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index] =
                 perframe_dynamic_offset + sizeof(MeshPerframeStorageBufferObject);
-            assert(m_p_global_render_resource->_storage_buffer
-                       ._global_upload_ringbuffers_end[m_command_info._current_frame_index] <=
-                   (m_p_global_render_resource->_storage_buffer
-                        ._global_upload_ringbuffers_begin[m_command_info._current_frame_index] +
-                    m_p_global_render_resource->_storage_buffer
-                        ._global_upload_ringbuffers_size[m_command_info._current_frame_index]));
+            assert(_storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index] <=
+                   (_storage_buffer._global_upload_ringbuffers_begin[m_command_info._current_frame_index] +
+                    _storage_buffer._global_upload_ringbuffers_size[m_command_info._current_frame_index]));
 
             MeshPointLightShadowPerframeStorageBufferObject& perframe_storage_buffer_object =
                 (*reinterpret_cast<MeshPointLightShadowPerframeStorageBufferObject*>(
-                    reinterpret_cast<uintptr_t>(
-                        m_p_global_render_resource->_storage_buffer._global_upload_ringbuffer_memory_pointer) +
+                    reinterpret_cast<uintptr_t>(_storage_buffer._global_upload_ringbuffer_memory_pointer) +
                     perframe_dynamic_offset));
             perframe_storage_buffer_object = _mesh_point_light_shadow_perframe_storage_buffer_object;
 
@@ -577,158 +511,140 @@ namespace Pilot
                     auto&       mesh_nodes = pair2.second;
 
                     uint32_t total_instance_count = static_cast<uint32_t>(mesh_nodes.size());
-                    if (total_instance_count > 0)
+                    if (total_instance_count == 0)
                     {
-                        // bind per mesh
-                        m_p_vulkan_context->_vkCmdBindDescriptorSets(m_command_info._current_command_buffer,
-                                                                     VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                                                     _render_pipelines[0].layout,
-                                                                     1,
-                                                                     1,
-                                                                     &mesh.mesh_vertex_blending_descriptor_set,
-                                                                     0,
-                                                                     NULL);
+                        continue;
+                    }
+                    // bind per mesh
+                    m_p_vulkan_context->_vkCmdBindDescriptorSets(command_buffer,
+                                                                 VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                                                 _render_pipelines[0].layout,
+                                                                 1,
+                                                                 1,
+                                                                 &mesh.mesh_vertex_blending_descriptor_set,
+                                                                 0,
+                                                                 NULL);
 
-                        VkBuffer     vertex_buffers[] = {mesh.mesh_vertex_position_buffer};
-                        VkDeviceSize offsets[]        = {0};
-                        m_p_vulkan_context->_vkCmdBindVertexBuffers(
-                            m_command_info._current_command_buffer, 0, 1, vertex_buffers, offsets);
-                        m_p_vulkan_context->_vkCmdBindIndexBuffer(
-                            m_command_info._current_command_buffer, mesh.mesh_index_buffer, 0, VK_INDEX_TYPE_UINT16);
+                    VkBuffer     vertex_buffers[] = {mesh.mesh_vertex_position_buffer};
+                    VkDeviceSize offsets[]        = {0};
+                    m_p_vulkan_context->_vkCmdBindVertexBuffers(command_buffer, 0, 1, vertex_buffers, offsets);
+                    m_p_vulkan_context->_vkCmdBindIndexBuffer(
+                        command_buffer, mesh.mesh_index_buffer, 0, VK_INDEX_TYPE_UINT16);
 
-                        uint32_t drawcall_max_instance_count =
-                            (sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject::mesh_instances) /
-                             sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject::mesh_instances[0]));
-                        uint32_t drawcall_count =
-                            roundUp(total_instance_count, drawcall_max_instance_count) / drawcall_max_instance_count;
+                    uint32_t drawcall_max_instance_count =
+                        (sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject::mesh_instances) /
+                         sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject::mesh_instances[0]));
+                    uint32_t drawcall_count =
+                        roundUp(total_instance_count, drawcall_max_instance_count) / drawcall_max_instance_count;
 
-                        for (uint32_t drawcall_index = 0; drawcall_index < drawcall_count; ++drawcall_index)
+                    for (uint32_t drawcall_index = 0; drawcall_index < drawcall_count; ++drawcall_index)
+                    {
+                        uint32_t current_instance_count =
+                            ((total_instance_count - drawcall_max_instance_count * drawcall_index) <
+                             drawcall_max_instance_count) ?
+                                (total_instance_count - drawcall_max_instance_count * drawcall_index) :
+                                drawcall_max_instance_count;
+
+                        // perdrawcall storage buffer
+                        uint32_t perdrawcall_dynamic_offset =
+                            roundUp(_storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index],
+                                    _storage_buffer._min_storage_buffer_offset_alignment);
+                        _storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index] =
+                            perdrawcall_dynamic_offset + sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject);
+                        assert(_storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index] <=
+                               (_storage_buffer._global_upload_ringbuffers_begin[m_command_info._current_frame_index] +
+                                _storage_buffer._global_upload_ringbuffers_size[m_command_info._current_frame_index]));
+
+                        MeshPointLightShadowPerdrawcallStorageBufferObject& perdrawcall_storage_buffer_object =
+                            (*reinterpret_cast<MeshPointLightShadowPerdrawcallStorageBufferObject*>(
+                                reinterpret_cast<uintptr_t>(_storage_buffer._global_upload_ringbuffer_memory_pointer) +
+                                perdrawcall_dynamic_offset));
+                        for (uint32_t i = 0; i < current_instance_count; ++i)
                         {
-                            uint32_t current_instance_count =
-                                ((total_instance_count - drawcall_max_instance_count * drawcall_index) <
-                                 drawcall_max_instance_count) ?
-                                    (total_instance_count - drawcall_max_instance_count * drawcall_index) :
-                                    drawcall_max_instance_count;
+                            perdrawcall_storage_buffer_object.mesh_instances[i].model_matrix =
+                                mesh_nodes[drawcall_max_instance_count * drawcall_index + i].model_matrix;
+                            perdrawcall_storage_buffer_object.mesh_instances[i].enable_vertex_blending =
+                                mesh_nodes[drawcall_max_instance_count * drawcall_index + i].enable_vertex_blending ?
+                                    1.0 :
+                                    -1.0;
+                        }
 
-                            // perdrawcall storage buffer
-                            uint32_t perdrawcall_dynamic_offset = roundUp(
-                                m_p_global_render_resource->_storage_buffer
-                                    ._global_upload_ringbuffers_end[m_command_info._current_frame_index],
-                                m_p_global_render_resource->_storage_buffer._min_storage_buffer_offset_alignment);
-                            m_p_global_render_resource->_storage_buffer
-                                ._global_upload_ringbuffers_end[m_command_info._current_frame_index] =
-                                perdrawcall_dynamic_offset + sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject);
-                            assert(m_p_global_render_resource->_storage_buffer
-                                       ._global_upload_ringbuffers_end[m_command_info._current_frame_index] <=
-                                   (m_p_global_render_resource->_storage_buffer
-                                        ._global_upload_ringbuffers_begin[m_command_info._current_frame_index] +
-                                    m_p_global_render_resource->_storage_buffer
-                                        ._global_upload_ringbuffers_size[m_command_info._current_frame_index]));
+                        // per drawcall vertex blending storage buffer
+                        uint32_t per_drawcall_vertex_blending_dynamic_offset;
+                        bool     least_one_enable_vertex_blending = true;
+                        for (uint32_t i = 0; i < current_instance_count; ++i)
+                        {
+                            if (!mesh_nodes[drawcall_max_instance_count * drawcall_index + i].enable_vertex_blending)
+                            {
+                                least_one_enable_vertex_blending = false;
+                                break;
+                            }
+                        }
+                        if (mesh.enable_vertex_blending)
+                        {
+                            per_drawcall_vertex_blending_dynamic_offset = roundUp(
+                                _storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index],
+                                _storage_buffer._min_storage_buffer_offset_alignment);
+                            _storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index] =
+                                per_drawcall_vertex_blending_dynamic_offset +
+                                sizeof(MeshPointLightShadowPerdrawcallVertexBlendingStorageBufferObject);
+                            assert(
+                                _storage_buffer._global_upload_ringbuffers_end[m_command_info._current_frame_index] <=
+                                (_storage_buffer._global_upload_ringbuffers_begin[m_command_info._current_frame_index] +
+                                 _storage_buffer._global_upload_ringbuffers_size[m_command_info._current_frame_index]));
 
-                            MeshPointLightShadowPerdrawcallStorageBufferObject& perdrawcall_storage_buffer_object =
-                                (*reinterpret_cast<MeshPointLightShadowPerdrawcallStorageBufferObject*>(
-                                    reinterpret_cast<uintptr_t>(m_p_global_render_resource->_storage_buffer
-                                                                    ._global_upload_ringbuffer_memory_pointer) +
-                                    perdrawcall_dynamic_offset));
+                            MeshPointLightShadowPerdrawcallVertexBlendingStorageBufferObject&
+                                per_drawcall_vertex_blending_storage_buffer_object =
+                                    (*reinterpret_cast<
+                                        MeshPointLightShadowPerdrawcallVertexBlendingStorageBufferObject*>(
+                                        reinterpret_cast<uintptr_t>(
+                                            _storage_buffer._global_upload_ringbuffer_memory_pointer) +
+                                        per_drawcall_vertex_blending_dynamic_offset));
                             for (uint32_t i = 0; i < current_instance_count; ++i)
                             {
-                                perdrawcall_storage_buffer_object.mesh_instances[i].model_matrix =
-                                    mesh_nodes[drawcall_max_instance_count * drawcall_index + i].model_matrix;
-                                perdrawcall_storage_buffer_object.mesh_instances[i].enable_vertex_blending =
-                                    mesh_nodes[drawcall_max_instance_count * drawcall_index + i]
-                                            .enable_vertex_blending ?
-                                        1.0 :
-                                        -1.0;
-                            }
-
-                            // per drawcall vertex blending storage buffer
-                            uint32_t per_drawcall_vertex_blending_dynamic_offset;
-                            bool     least_one_enable_vertex_blending = true;
-                            for (uint32_t i = 0; i < current_instance_count; ++i)
-                            {
-                                if (!mesh_nodes[drawcall_max_instance_count * drawcall_index + i]
-                                         .enable_vertex_blending)
+                                if (mesh_nodes[drawcall_max_instance_count * drawcall_index + i].enable_vertex_blending)
                                 {
-                                    least_one_enable_vertex_blending = false;
-                                    break;
-                                }
-                            }
-                            if (mesh.enable_vertex_blending)
-                            {
-                                per_drawcall_vertex_blending_dynamic_offset = roundUp(
-                                    m_p_global_render_resource->_storage_buffer
-                                        ._global_upload_ringbuffers_end[m_command_info._current_frame_index],
-                                    m_p_global_render_resource->_storage_buffer._min_storage_buffer_offset_alignment);
-                                m_p_global_render_resource->_storage_buffer
-                                    ._global_upload_ringbuffers_end[m_command_info._current_frame_index] =
-                                    per_drawcall_vertex_blending_dynamic_offset +
-                                    sizeof(MeshPointLightShadowPerdrawcallVertexBlendingStorageBufferObject);
-                                assert(m_p_global_render_resource->_storage_buffer
-                                           ._global_upload_ringbuffers_end[m_command_info._current_frame_index] <=
-                                       (m_p_global_render_resource->_storage_buffer
-                                            ._global_upload_ringbuffers_begin[m_command_info._current_frame_index] +
-                                        m_p_global_render_resource->_storage_buffer
-                                            ._global_upload_ringbuffers_size[m_command_info._current_frame_index]));
-
-                                MeshPointLightShadowPerdrawcallVertexBlendingStorageBufferObject&
-                                    per_drawcall_vertex_blending_storage_buffer_object =
-                                        (*reinterpret_cast<
-                                            MeshPointLightShadowPerdrawcallVertexBlendingStorageBufferObject*>(
-                                            reinterpret_cast<uintptr_t>(m_p_global_render_resource->_storage_buffer
-                                                                            ._global_upload_ringbuffer_memory_pointer) +
-                                            per_drawcall_vertex_blending_dynamic_offset));
-                                for (uint32_t i = 0; i < current_instance_count; ++i)
-                                {
-                                    if (mesh_nodes[drawcall_max_instance_count * drawcall_index + i]
-                                            .enable_vertex_blending)
+                                    for (uint32_t j = 0; j < m_mesh_vertex_blending_max_joint_count; ++j)
                                     {
-                                        for (uint32_t j = 0; j < m_mesh_vertex_blending_max_joint_count; ++j)
-                                        {
-                                            per_drawcall_vertex_blending_storage_buffer_object
-                                                .joint_matrices[m_mesh_vertex_blending_max_joint_count * i + j] =
-                                                mesh_nodes[drawcall_max_instance_count * drawcall_index + i]
-                                                    .joint_matrices[j];
-                                        }
+                                        per_drawcall_vertex_blending_storage_buffer_object
+                                            .joint_matrices[m_mesh_vertex_blending_max_joint_count * i + j] =
+                                            mesh_nodes[drawcall_max_instance_count * drawcall_index + i]
+                                                .joint_matrices[j];
                                     }
                                 }
                             }
-                            else
-                            {
-                                per_drawcall_vertex_blending_dynamic_offset = 0;
-                            }
-
-                            // bind perdrawcall
-                            uint32_t dynamic_offsets[3] = {perframe_dynamic_offset,
-                                                           perdrawcall_dynamic_offset,
-                                                           per_drawcall_vertex_blending_dynamic_offset};
-                            m_p_vulkan_context->_vkCmdBindDescriptorSets(
-                                m_command_info._current_command_buffer,
-                                VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                _render_pipelines[0].layout,
-                                0,
-                                1,
-                                &_descriptor_infos[0].descriptor_set,
-                                (sizeof(dynamic_offsets) / sizeof(dynamic_offsets[0])),
-                                dynamic_offsets);
-
-                            m_p_vulkan_context->_vkCmdDrawIndexed(m_command_info._current_command_buffer,
-                                                                  mesh.mesh_index_count,
-                                                                  current_instance_count,
-                                                                  0,
-                                                                  0,
-                                                                  0);
                         }
+                        else
+                        {
+                            per_drawcall_vertex_blending_dynamic_offset = 0;
+                        }
+
+                        // bind perdrawcall
+                        uint32_t dynamic_offsets[3] = {perframe_dynamic_offset,
+                                                       perdrawcall_dynamic_offset,
+                                                       per_drawcall_vertex_blending_dynamic_offset};
+                        m_p_vulkan_context->_vkCmdBindDescriptorSets(command_buffer,
+                                                                     VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                                                     _render_pipelines[0].layout,
+                                                                     0,
+                                                                     1,
+                                                                     &_descriptor_infos[0].descriptor_set,
+                                                                     std::size(dynamic_offsets),
+                                                                     dynamic_offsets);
+
+                        m_p_vulkan_context->_vkCmdDrawIndexed(
+                            command_buffer, mesh.mesh_index_count, current_instance_count, 0, 0, 0);
                     }
                 }
             }
 
             if (m_render_config._enable_debug_untils_label)
             {
-                m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(m_command_info._current_command_buffer);
+                m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(command_buffer);
             }
         }
 
-        m_p_vulkan_context->_vkCmdEndRenderPass(m_command_info._current_command_buffer);
+        m_p_vulkan_context->_vkCmdEndRenderPass(command_buffer);
     }
 
 } // namespace Pilot

--- a/engine/source/runtime/function/render/source/vulkan_manager/passes/render_passes.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/passes/render_passes.cpp
@@ -14,11 +14,6 @@ bool Pilot::PVulkanManager::initializeRenderPass()
     m_point_light_shadow_pass.initialize();
     m_directional_light_shadow_pass.initialize();
 
-    PLightPassHelperInfo light_pass_helper_info {};
-    light_pass_helper_info.point_light_shadow_color_image_view = m_point_light_shadow_pass.getFramebufferImageViews()[0];
-    light_pass_helper_info.directional_light_shadow_color_image_view =
-        m_directional_light_shadow_pass._framebuffer.attachments[0].view;
-    m_main_camera_pass.setHelperInfo(light_pass_helper_info);
     m_main_camera_pass.initialize();
 
     auto descriptor_layouts = m_main_camera_pass.getDescriptorSetLayouts();
@@ -29,13 +24,17 @@ bool Pilot::PVulkanManager::initializeRenderPass()
     m_point_light_shadow_pass.postInitialize();
     m_directional_light_shadow_pass.postInitialize();
 
-    m_tone_mapping_pass.initialize(m_main_camera_pass.getRenderPass(), m_main_camera_pass.getFramebufferImageViews()[_main_camera_pass_backup_buffer_odd]);
-
-    m_color_grading_pass.initialize(m_main_camera_pass.getRenderPass(), m_main_camera_pass.getFramebufferImageViews()[_main_camera_pass_backup_buffer_even]);
+    //m_tone_mapping_pass.initialize(m_main_camera_pass.getRenderPass(), m_main_camera_pass.getFramebufferImageViews()[_main_camera_pass_backup_buffer_odd]);
+    //m_color_grading_pass.initialize(m_main_camera_pass.getRenderPass(), m_main_camera_pass.getFramebufferImageViews()[_main_camera_pass_backup_buffer_even]);
+    m_tone_mapping_pass.initialize(m_main_camera_pass.getRenderPass());
+    m_color_grading_pass.initialize(m_main_camera_pass.getRenderPass());
 
     m_ui_pass.initialize(m_main_camera_pass.getRenderPass());
 
-    m_combine_ui_pass.initialize(m_main_camera_pass.getRenderPass(), m_main_camera_pass.getFramebufferImageViews()[_main_camera_pass_backup_buffer_odd], m_main_camera_pass.getFramebufferImageViews()[_main_camera_pass_backup_buffer_even]);
+    m_combine_ui_pass.initialize(
+        m_main_camera_pass.getRenderPass(),
+        m_vulkan_context.GetImageView(std::hash<_main_camera_pass_buffer>()(_main_camera_pass_backup_buffer_odd)),
+        m_vulkan_context.GetImageView(std::hash<_main_camera_pass_buffer>()(_main_camera_pass_backup_buffer_even)));
 
     m_mouse_pick_pass._per_mesh_layout = descriptor_layouts[PMainCameraPass::LayoutType::_per_mesh];
     m_mouse_pick_pass.initialize();

--- a/engine/source/runtime/function/render/source/vulkan_manager/passes/ui.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/passes/ui.cpp
@@ -204,6 +204,7 @@ namespace Pilot
 
     void PUIPass::draw(void* ui_state)
     {
+        auto& command_buffer = m_command_info._current_command_buffer;
         if (NULL != m_surface_ui)
         {
             ImGui_ImplVulkan_NewFrame();
@@ -216,16 +217,16 @@ namespace Pilot
             {
                 VkDebugUtilsLabelEXT label_info = {
                     VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "ImGUI", {1.0f, 1.0f, 1.0f, 1.0f}};
-                m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(m_command_info._current_command_buffer, &label_info);
+                m_p_vulkan_context->_vkCmdBeginDebugUtilsLabelEXT(command_buffer, &label_info);
             }
 
             ImGui::Render();
 
-            ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), m_command_info._current_command_buffer);
+            ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), command_buffer);
 
             if (m_render_config._enable_debug_untils_label)
             {
-                m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(m_command_info._current_command_buffer);
+                m_p_vulkan_context->_vkCmdEndDebugUtilsLabelEXT(command_buffer);
             }
         }
     }

--- a/engine/source/runtime/function/render/source/vulkan_manager/passes/vulkan_render_pass.cpp
+++ b/engine/source/runtime/function/render/source/vulkan_manager/passes/vulkan_render_pass.cpp
@@ -1,5 +1,6 @@
 #include "runtime/function/render/include/render/vulkan_manager/vulkan_render_pass.h"
 #include "runtime/function/render/include/render/vulkan_manager/vulkan_context.h"
+#include "runtime/function/render/include/render/vulkan_manager/vulkan_util.h"
 
 Pilot::PVulkanContext*        Pilot::PRenderPassBase::m_p_vulkan_context         = nullptr;
 VkDescriptorPool              Pilot::PRenderPassBase::m_descriptor_pool          = VK_NULL_HANDLE;
@@ -26,15 +27,6 @@ namespace Pilot
     void                     PRenderPassBase::draw() {}
     void                     PRenderPassBase::postInitialize() {}
     VkRenderPass             PRenderPassBase::getRenderPass() { return _framebuffer.render_pass; }
-    std::vector<VkImageView> PRenderPassBase::getFramebufferImageViews()
-    {
-        std::vector<VkImageView> image_views;
-        for (auto& attach : _framebuffer.attachments)
-        {
-            image_views.push_back(attach.view);
-        }
-        return image_views;
-    }
     std::vector<VkDescriptorSetLayout> PRenderPassBase::getDescriptorSetLayouts()
     {
         std::vector<VkDescriptorSetLayout> layouts;
@@ -43,5 +35,75 @@ namespace Pilot
             layouts.push_back(desc.layout);
         }
         return layouts;
+    }
+    void PRenderPassBase::FillShaderStageCreateInfo(VkPipelineShaderStageCreateInfo*  fill,
+                                                    VkDevice                          _device,
+                                                    const std::vector<unsigned char>& vert,
+                                                    const std::vector<unsigned char>& frag)
+    {
+
+        VkShaderModule vert_shader_module = PVulkanUtil::createShaderModule(_device, vert);
+        VkShaderModule frag_shader_module = PVulkanUtil::createShaderModule(_device, frag);
+        module_reference.push_back(tuple<VkDevice, VkShaderModule>(_device, vert_shader_module));
+        module_reference.push_back(tuple<VkDevice, VkShaderModule>(_device, frag_shader_module));
+
+        VkPipelineShaderStageCreateInfo vert_pipeline_shader_stage_create_info {};
+        vert_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        vert_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_VERTEX_BIT;
+        vert_pipeline_shader_stage_create_info.module = vert_shader_module;
+        vert_pipeline_shader_stage_create_info.pName  = "main";
+
+        VkPipelineShaderStageCreateInfo frag_pipeline_shader_stage_create_info {};
+        frag_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        frag_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+        frag_pipeline_shader_stage_create_info.module = frag_shader_module;
+        frag_pipeline_shader_stage_create_info.pName  = "main";
+
+        fill[0] = vert_pipeline_shader_stage_create_info;
+        fill[1] = frag_pipeline_shader_stage_create_info;
+    }
+    void PRenderPassBase::FillShaderStageCreateInfo(VkPipelineShaderStageCreateInfo*  fill,
+                                                    VkDevice                          _device,
+                                                    const std::vector<unsigned char>& vert,
+                                                    const std::vector<unsigned char>& geom,
+                                                    const std::vector<unsigned char>& frag)
+    {
+
+        VkShaderModule vert_shader_module = PVulkanUtil::createShaderModule(_device, vert);
+        VkShaderModule geom_shader_module = PVulkanUtil::createShaderModule(_device, geom);
+        VkShaderModule frag_shader_module = PVulkanUtil::createShaderModule(_device, frag);
+        module_reference.push_back(tuple<VkDevice, VkShaderModule>(_device, vert_shader_module));
+        module_reference.push_back(tuple<VkDevice, VkShaderModule>(_device, geom_shader_module));
+        module_reference.push_back(tuple<VkDevice, VkShaderModule>(_device, frag_shader_module));
+
+        VkPipelineShaderStageCreateInfo vert_pipeline_shader_stage_create_info {};
+        vert_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        vert_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_VERTEX_BIT;
+        vert_pipeline_shader_stage_create_info.module = vert_shader_module;
+        vert_pipeline_shader_stage_create_info.pName  = "main";
+
+        VkPipelineShaderStageCreateInfo geom_pipeline_shader_stage_create_info {};
+        geom_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        geom_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_GEOMETRY_BIT;
+        geom_pipeline_shader_stage_create_info.module = geom_shader_module;
+        geom_pipeline_shader_stage_create_info.pName  = "main";
+
+        VkPipelineShaderStageCreateInfo frag_pipeline_shader_stage_create_info {};
+        frag_pipeline_shader_stage_create_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        frag_pipeline_shader_stage_create_info.stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+        frag_pipeline_shader_stage_create_info.module = frag_shader_module;
+        frag_pipeline_shader_stage_create_info.pName  = "main";
+
+        fill[0] = vert_pipeline_shader_stage_create_info;
+        fill[1] = geom_pipeline_shader_stage_create_info;
+        fill[2] = frag_pipeline_shader_stage_create_info;
+    }
+    void PRenderPassBase::ModuleGC()
+    {
+        for (auto& it : module_reference)
+        {
+            vkDestroyShaderModule(std::get<0>(it), std::get<1>(it), nullptr);
+        }
+        module_reference.clear();
     }
 } // namespace Pilot


### PR DESCRIPTION
简化创建ShaderModule的代码。
修复一个ShaderModule未释放错误在 directional_light_shadow.cpp line 363.

简化Image和ImageView创建（使用单例模式）。
使用std::size()获取数组长度而不是sizeof(array)/sizeof(array[0])
移除graphics pipeline 创建阶段不必要的viewport和scissor引用。