### PR TITLE
Allow using ninja on default if ninja is found on Linux platform

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -2,7 +2,7 @@
 
 if test \( $# -gt 2 \);
 then
-    echo "Usage: build.sh config [build-tool]"
+    echo "Usage: ./build_linux.sh config [build-tool]"
     echo ""
     echo "config:"
     echo "  debug   -   build with the debug configuration"
@@ -26,9 +26,8 @@ elif test \( \( -n "$2" \) -a \( "$2" = "makefile" \) \);then
 elif test \( \( -n "$2" \) -a \( "$2" = "ninja" \) \);then
     CMAKE_ARG_BUILD_TOOL_TYPE_CONFIG="-G Ninja"
 else
-    if test \( -n "$2" \);then
-        echo "The build-tool \"$2\" is not supported!"
-    fi
+    echo "The build-tool \"$2\" is not supported!"
+    exit 1
 fi
 
 if test \( \( -n "$1" \) -a \( "$1" = "debug" \) \);then 
@@ -50,7 +49,7 @@ cd "${MY_DIR}"
 
 mkdir -p "engine/shader/generated/spv"
 
-export CC=`command -v clang`
-export CXX=`command -v clang++`
+export CC=clang
+export CXX=clang++
 cmake -S . -B build "${CMAKE_ARG_BUILD_TYPE_CONFIG}" "${CMAKE_ARG_BUILD_TOOL_TYPE_CONFIG}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 cmake --build "${MY_DIR}/build" -- all

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,16 +1,35 @@
 #!/bin/bash
 
-if test \( $# -ne 1 \);
+if test \( $# -gt 2 \);
 then
-    echo "Usage: build.sh arch config"
+    echo "Usage: build.sh config [build-tool]"
     echo ""
-    echo "Configs:"
+    echo "config:"
     echo "  debug   -   build with the debug configuration"
     echo "  release -   build with the release configuration"
+    echo ""
+    echo "build-tool:"
+    echo "  make    -   build with Unix Make"
+    echo "  ninja   -   build with Ninja"
     echo ""
     exit 1
 fi
 
+if test \( $# -eq 1 \) ;then
+    if command -v ninja &> /dev/null; then
+        CMAKE_ARG_BUILD_TOOL_TYPE_CONFIG="-G Ninja"
+    else
+        CMAKE_ARG_BUILD_TOOL_TYPE_CONFIG="-G Unix Makefiles"
+    fi
+elif test \( \( -n "$2" \) -a \( "$2" = "makefile" \) \);then
+    CMAKE_ARG_BUILD_TOOL_TYPE_CONFIG="-G Unix Makefiles"
+elif test \( \( -n "$2" \) -a \( "$2" = "ninja" \) \);then
+    CMAKE_ARG_BUILD_TOOL_TYPE_CONFIG="-G Ninja"
+else
+    if test \( -n "$2" \);then
+        echo "The build-tool \"$2\" is not supported!"
+    fi
+fi
 
 if test \( \( -n "$1" \) -a \( "$1" = "debug" \) \);then 
     CMAKE_ARG_BUILD_TYPE_CONFIG="-DCMAKE_BUILD_TYPE=Debug"
@@ -31,9 +50,7 @@ cd "${MY_DIR}"
 
 mkdir -p "engine/shader/generated/spv"
 
-
-export CC=clang
-export CXX=clang++
-cmake -S . -B build "${CMAKE_ARG_BUILD_TYPE_CONFIG}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-
-cmake --build "${MY_DIR}/build" -- -j
+export CC=`command -v clang`
+export CXX=`command -v clang++`
+cmake -S . -B build "${CMAKE_ARG_BUILD_TYPE_CONFIG}" "${CMAKE_ARG_BUILD_TOOL_TYPE_CONFIG}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake --build "${MY_DIR}/build" -- all


### PR DESCRIPTION
Allow using ninja on default if ninja is found. It's enabled on the Linux platform by the build_linux.sh.

Ninja is much faster than Unix Make. It reduced the build time from 63.96 seconds to 12.14 seconds,
which means a 5x times speedup.

![2022-05-07_12-33](https://user-images.githubusercontent.com/24508452/167240054-acd6a02f-9ba9-4a39-8745-6a447fd103bb.png)
