### PR TITLE
Add the building script for compile db

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,19 @@ Or you can execute the **build_macos.sh** to build the binaries.
 ### Build on Ubuntu 20.04
 You can execute the **build_linux.sh** to build the binaries.
 
-### Documentation
+## Documentation
 For documentation, please refer to the Wiki section.
+
+## Extra
+
+### Build compile db
+
+You can build `compile_commands.json` with the following commands when `Unix Makefiles` generaters are avaliable. `compile_commands.json` is the file required by `clangd` language server, which is
+a backend for cpp lsp-mode in Emacs.
+
+For Windows:
+
+``` powershell
+cmake -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -S . -B compile_db_temp -G "Unix Makefiles"
+copy compile_db_temp\compile_commands.json .
+```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For documentation, please refer to the Wiki section.
 
 ## Extra
 
-### Build compile db
+### Generate Compilation Database
 
 You can build `compile_commands.json` with the following commands when `Unix Makefiles` generaters are avaliable. `compile_commands.json` is the file
 required by `clangd` language server, which is a backend for cpp lsp-mode in Emacs.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ For documentation, please refer to the Wiki section.
 
 ### Build compile db
 
-You can build `compile_commands.json` with the following commands when `Unix Makefiles` generaters are avaliable. `compile_commands.json` is the file required by `clangd` language server, which is
-a backend for cpp lsp-mode in Emacs.
+You can build `compile_commands.json` with the following commands when `Unix Makefiles` generaters are avaliable. `compile_commands.json` is the file
+required by `clangd` language server, which is a backend for cpp lsp-mode in Emacs.
 
 For Windows:
 

--- a/build_compile_db.bat
+++ b/build_compile_db.bat
@@ -1,5 +1,0 @@
-@echo off
-
-rem export compile_commands.json for clangd lsp
-cmake -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -S . -B compile_db_temp -G "Unix Makefiles"
-copy compile_db_temp\compile_commands.json .

--- a/build_compile_db.bat
+++ b/build_compile_db.bat
@@ -1,0 +1,5 @@
+@echo off
+
+rem export compile_commands.json for clangd lsp
+cmake -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -S . -B compile_db_temp -G "Unix Makefiles"
+copy compile_db_temp\compile_commands.json .

--- a/scripts/generate_compile_db.bat
+++ b/scripts/generate_compile_db.bat
@@ -1,0 +1,5 @@
+@echo off
+
+rem export compile_commands.json for clangd lsp
+cmake -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -S . -B .\compile_db_temp -G "Unix Makefiles"
+copy .\compile_db_temp\compile_commands.json .


### PR DESCRIPTION
This PR is helpful for developers using Emacs as code editor. 

When using `lsp-mode` with `clangd` language server, `compile_commands.json` is required to find the includes properly. (per https://emacs-lsp.github.io/lsp-mode/tutorials/CPP-guide/)

* Added a .bat script builds and copys `compile_commands.json`
* Updated doc accordingly

----
screenshot:
![image](https://user-images.githubusercontent.com/1454871/168510895-ada1a2a9-2788-46ea-b84a-2696fc1eb29a.png)

