### PR TITLE
Fix level.cpp

### DIFF
--- a/engine/source/runtime/function/framework/level/level.cpp
+++ b/engine/source/runtime/function/framework/level/level.cpp
@@ -27,24 +27,25 @@ namespace Pilot
         GObjectID object_id = ObjectIDAllocator::alloc();
         ASSERT(object_id != k_invalid_gobject_id);
 
-        std::shared_ptr<GObject> gobject = std::make_shared<GObject>(object_id);
-
-        if (gobject == nullptr)
+        std::shared_ptr<GObject> gobject;
+        try
+        {
+            gobject = std::make_shared<GObject>(object_id);
+        }
+        catch(const std::bad_alloc&)
         {
             LOG_FATAL("cannot allocate memory for new gobject");
         }
+
+        bool is_loaded = gobject->load(object_instance_res);
+        if (is_loaded)
+        {
+            m_gobjects.emplace(object_id, gobject);
+        }
         else
         {
-            bool is_loaded = gobject->load(object_instance_res);
-            if (is_loaded)
-            {
-                m_gobjects.emplace(object_id, gobject);
-            }
-            else
-            {
-                LOG_ERROR("loading object " + object_instance_res.m_name + " failed");
-                return k_invalid_gobject_id;
-            }
+            LOG_ERROR("loading object " + object_instance_res.m_name + " failed");
+            return k_invalid_gobject_id;
         }
         return object_id;
     }


### PR DESCRIPTION
修复了对 `std::make_shared` 的错误处理. `std::make_shared` 无法分配时会抛出异常, 而不是返回 `nullptr`.

> May throw [std::bad_alloc](https://en.cppreference.com/w/cpp/memory/new/bad_alloc) or any exception thrown by the constructor of T.

参考: <https://en.cppreference.com/w/cpp/memory/shared_ptr/make_shared>