### PR TITLE
Fix color grading texture's mipmap level bug

### DIFF
--- a/engine/source/runtime/function/render/render_resource.cpp
+++ b/engine/source/runtime/function/render/render_resource.cpp
@@ -82,7 +82,8 @@ namespace Pilot
             color_grading_map->m_width,
             color_grading_map->m_height,
             color_grading_map->m_pixels,
-            color_grading_map->m_format);
+            color_grading_map->m_format,
+            1);
     }
 
     void RenderResource::uploadGameObjectRenderResource(std::shared_ptr<RHI> rhi,


### PR DESCRIPTION
修复color grading纹理mipmap级别问题（只需一层mipmap，否则会导致颜色断层）