### PR TITLE
Using working directory as pilot root directory

### DIFF
--- a/engine/source/editor/CMakeLists.txt
+++ b/engine/source/editor/CMakeLists.txt
@@ -15,7 +15,9 @@ target_include_directories(
 
 set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 17 OUTPUT_NAME "PilotEditor")
 set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Engine")
-set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${BINARY_ROOT_DIR}")
+if(MSVC)
+	set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${BINARY_ROOT_DIR}")
+endif()
 
 target_compile_options(${TARGET_NAME} PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/WX->")
 

--- a/engine/source/editor/CMakeLists.txt
+++ b/engine/source/editor/CMakeLists.txt
@@ -8,8 +8,6 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${EDITOR_HEADERS} ${EDITOR
 
 add_executable(${TARGET_NAME} ${EDITOR_HEADERS} ${EDITOR_SOURCES} ${EDITOR_RESOURCE})
 
-add_compile_definitions("PILOT_ROOT_DIR=${BINARY_ROOT_DIR}")
-
 target_include_directories(
   ${TARGET_NAME} 
   PUBLIC $<BUILD_INTERFACE:${THIRD_PARTY_DIR}/stb>
@@ -17,6 +15,7 @@ target_include_directories(
 
 set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 17 OUTPUT_NAME "PilotEditor")
 set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Engine")
+set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${BINARY_ROOT_DIR}")
 
 target_compile_options(${TARGET_NAME} PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/WX->")
 

--- a/engine/source/editor/source/main.cpp
+++ b/engine/source/editor/source/main.cpp
@@ -13,7 +13,7 @@
 
 int main(int argc, char** argv)
 {
-    std::filesystem::path pilot_root_folder = std::filesystem::path(PILOT_XSTR(PILOT_ROOT_DIR));
+    std::filesystem::path pilot_root_folder = std::filesystem::current_path();
 
     Pilot::EngineInitParams params;
     params.m_root_folder      = pilot_root_folder;


### PR DESCRIPTION
原本这么做可能是因为 Visual Studio 的调试器默认工作目录为源文件所在的目录, 通过在 CMake 中提前指定工作目录来使 Visual Studio 和其他 IDE 的行为保持一直来避免这个问题.  
新使用的 CMake 代码适用于 3.8 以及之后版本, 符合当前 CMake 版本最低要求. 不过此修改将不再允许 Visual Studio 直接打开该项目, 只能使用 CMake 生成的项目解决方案文件(.sln)打开.  
#225 
(提交时发现已经存在相关PR #228, 这里给出另一个解决方案)  